### PR TITLE
Rails adapter initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Measured Rails [![Build Status](https://travis-ci.org/Shopify/measured-rails.svg)](https://travis-ci.org/Shopify/measured-rails)
 
-ActiveRecord adapter for assigning and managing measurements with their units provided by the [measured](https://github.com/Shopify/measured) gem.
+This gem is the Rails integration for the [measured](https://github.com/Shopify/measured) gem.
+
+It provides ActiveRecord adapter for persisting and retrieving measurements with their units, and model validations.
 
 ## Installation
 
@@ -16,8 +18,94 @@ Or stand alone:
 
 ## Usage
 
-**WIP**
+### ActiveRecord
 
+Columns are expected to have the `_value` and `_unit` suffix, and be `DECIMAL` and `VARCHAR`, and defaults are accepted:
+
+```ruby
+class AddWeightAndLengthToThings < ActiveRecord::Migration
+  def change
+    add_column :things, :minimum_weight_value, :decimal, precision: 10, scale: 2
+    add_column :things, :minimum_weight_unit, :string, limit: 12
+
+    add_column :things, :total_length_value, :decimal, precision: 10, scale: 2, default: 0
+    add_column :things, :total_length_unit, :string, limit: 12, default: "cm"
+  end
+end
+```
+
+A column can be declared as a measurement with its measurement subclass:
+
+```ruby
+class Thing < ActiveRecord::Base
+  measured Measured::Weight, :minimum_weight
+  measured Measured::Length, :total_length
+end
+```
+
+There are some simpler methods for predefined types:
+
+```ruby
+class Thing < ActiveRecord::Base
+  measured_weight :minimum_weight
+  measured_length :total_length
+end
+```
+
+This will allow you to access and assign a measurement object:
+
+```ruby
+thing = Thing.new
+thing.minimum_weight = Measured::Weight.new(10, "g")
+thing.minimum_weight_unit      # "g"
+thing.minimum_weight_value    # 10
+```
+
+Order of assignment does not matter, and each property can be assigned separately and with mass assignment:
+
+```ruby
+params = { total_length_unit: "cm", total_length_value: "3" }
+thing = Thing.new(params)
+thing.total_length   # #<Measured::Length: 3 cm>
+```
+
+### Validations
+
+Validations are available:
+
+```ruby
+class Thing < ActiveRecord::Base
+  measured_length :total_length
+
+  validates :total_length, measured: true
+end
+```
+
+This will validate that the unit is defined on the measurement, and that there is a value.
+
+Rather than `true` the validation can accept a hash with the following options:
+
+* `message`: Override the default "is invalid" message.
+* `units`: A subset of units available for this measurement. Units must be in existing measurement.
+
+Validations can be combined with `presence` validator.
+
+**Note:** Validations are strongly recommended since assigning an invalid unit will cause the measurement to return `nil`, even if there is a value:
+
+```ruby
+thing = Thing.new
+thing.total_length_value = 1
+thing.total_length_unit = "invalid"
+thing.total_length  # nil
+
+```
+
+
+## Tests
+
+```
+$ bundle exec rake test
+```
 
 ## Contributing
 

--- a/lib/measured-rails.rb
+++ b/lib/measured-rails.rb
@@ -1,13 +1,4 @@
-require "measured/rails/version"
-require "measured"
+require "measured/rails/base"
 
-require "rails"
-
-module Measured
-  module Rails
-  end
-end
-
-if defined? Rails
-  require "measured/rails/railtie"
-end
+require "measured/rails/units/length"
+require "measured/rails/units/weight"

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -1,9 +1,71 @@
-module Measured::Rails
+module Measured::Rails::ActiveRecord
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def measured
+    def measured(measured_class, *fields)
+      options = fields.extract_options!
+      options = {}.merge(options)
 
+      measured_class = measured_class.constantize if measured_class.is_a?(String)
+
+      raise Measured::Rails::Error, "Expecting #{ measured_class } to be a subclass of Measured::Measurable" if !measured_class.is_a?(Class) || !measured_class.ancestors.include?(Measured::Measurable)
+
+      options[:class] = measured_class
+
+      fields.map(&:to_sym).each do |field|
+        raise Measured::Rails::Error, "The field #{ field } has already been measured" if measured_fields.keys.include?(field)
+        measured_fields[field] = options
+
+        # Reader to retrieve measured object
+        define_method(field) do
+          value = public_send("#{ field }_value")
+          unit = public_send("#{ field }_unit")
+
+          return nil unless value && unit
+
+          instance = instance_variable_get("@measured_#{ field }")
+          new_instance = begin
+            measured_class.new(value, unit)
+          rescue Measured::UnitError
+            nil
+          end
+
+          if instance && instance == new_instance
+            instance
+          else
+            instance_variable_set("@measured_#{ field }", new_instance)
+          end
+        end
+
+        # Writer to assign measured object
+        define_method("#{ field }=") do |incoming|
+          if incoming.is_a?(measured_class)
+            instance_variable_set("@measured_#{ field }", incoming)
+            public_send("#{ field }_value=", incoming.value)
+            public_send("#{ field }_unit=", incoming.unit)
+          else
+            instance_variable_set("@measured_#{ field }", nil)
+            public_send("#{ field }_value=", nil)
+            public_send("#{ field }_unit=", nil)
+          end
+        end
+
+        # Writer to override unit assignment
+        define_method("#{ field }_unit=") do |incoming|
+          incoming = measured_class.conversion.to_unit_name(incoming) if measured_class.valid_unit?(incoming)
+          write_attribute("#{ field }_unit", incoming)
+        end
+
+      end
     end
+
+    def measured_fields
+      @measured_fields ||= {}
+    end
+
   end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ::ActiveRecord::Base.send :include, Measured::Rails::ActiveRecord
 end

--- a/lib/measured/rails/base.rb
+++ b/lib/measured/rails/base.rb
@@ -1,0 +1,17 @@
+require "measured/rails/version"
+require "measured"
+
+require "active_support"
+
+module Measured
+  module Rails
+    class Error < StandardError ; end
+  end
+end
+
+require "measured/rails/active_record"
+require "measured/rails/validations"
+
+if defined? Rails
+  require "measured/rails/railtie"
+end

--- a/lib/measured/rails/units/length.rb
+++ b/lib/measured/rails/units/length.rb
@@ -1,0 +1,13 @@
+module Measured::Rails::ActiveRecord::Length
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def measured_length(*fields)
+      measured(Measured::Length, *fields)
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ::ActiveRecord::Base.send :include, Measured::Rails::ActiveRecord::Length
+end

--- a/lib/measured/rails/units/weight.rb
+++ b/lib/measured/rails/units/weight.rb
@@ -1,0 +1,13 @@
+module Measured::Rails::ActiveRecord::Weight
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def measured_weight(*fields)
+      measured(Measured::Weight, *fields)
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ::ActiveRecord::Base.send :include, Measured::Rails::ActiveRecord::Weight
+end

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -1,0 +1,18 @@
+class MeasuredValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, measurable)
+    measured_config = record.class.measured_fields[attribute]
+
+    measured_class = measured_config[:class]
+    measurable_unit = record.send("#{ attribute }_unit")
+    measurable_value = record.send("#{ attribute }_value")
+
+    message = options[:message] || "is not a valid unit"
+
+    if options[:units]
+      valid_units = [options[:units]].flatten.map{|u| measured_class.conversion.to_unit_name(u) }
+      record.errors.add(attribute, message) unless valid_units.include?(measured_class.conversion.to_unit_name(measurable_unit))
+    end
+
+    record.errors.add(attribute, message) unless measured_class.valid_unit?(measurable_unit)
+  end
+end

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rails", ">= 4.0"
-  spec.add_runtime_dependency "measured", "0.0.1"
+  spec.add_runtime_dependency "measured", "0.0.4"
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Measured::Rails::VERSION
   spec.authors       = ["Kevin McPhillips"]
   spec.email         = ["github@kevinmcphillips.ca"]
-  spec.summary       = %q{ActiveRecord for measured}
-  spec.description   = %q{ActiveRecord adapter for assigning and managing measurements with their units provided by the measured gem.}
+  spec.summary       = %q{Rails adaptor for measured}
+  spec.description   = %q{Rails adapter for assigning and managing measurements with their units provided by the measured gem.}
   spec.homepage      = "https://github.com/Shopify/measured-rails"
   spec.license       = "MIT"
 
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "mocha", "~> 1.1.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "sqlite3"
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -2,9 +2,296 @@ require "test_helper"
 
 class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
   setup do
+    reset_db
   end
 
-  test ".measured should be tested" do
-    skip
+  test ".measured raises if called with something that isn't a Measured::Measurable" do
+    assert_raises Measured::Rails::Error do
+      Thing.measured(Object, :field)
+    end
+  end
+
+  test ".measured raises if called with something that isn't a class" do
+    assert_raises Measured::Rails::Error do
+      Thing.measured(:not_correct, :field)
+    end
+  end
+
+  test ".measured raises if you attempt to define a field twice" do
+    assert_raises Measured::Rails::Error do
+      Thing.measured Measured::Length, :height
+    end
+  end
+
+  test ".measured defines a reader for the field" do
+    assert_equal length, thing.length
+  end
+
+  test ".measured defines a writer for the field that returns" do
+    assert_equal new_length, thing.length=(new_length)
+  end
+
+  test ".measured_fields returns the configuration for all measured fields on the class" do
+    expected = {
+      length: { class: Measured::Length },
+      width: { class: Measured::Length },
+      height: { class: Measured::Length },
+      total_weight: { class: Measured::Weight },
+      extra_weight: { class: Measured::Weight }
+    }
+
+    assert_equal expected, Thing.measured_fields
+  end
+
+  test "reader returns the exact same object if the values are equivalent" do
+    thing.length = new_length
+    assert_equal new_length.object_id, thing.length.object_id
+  end
+
+  test "reader creates an instance from the _value and _unit columns" do
+    thing = Thing.new
+    thing.width_value = 23
+    thing.width_unit = "ft"
+    assert_equal Measured::Length.new(23, :ft), thing.width
+  end
+
+  test "reader creates creating an instance from columns caches the same object" do
+    thing = Thing.new
+    thing.width_value = 23
+    thing.width_unit = "ft"
+    assert_equal thing.width.object_id, thing.width.object_id
+  end
+
+  test "reader deals with only the _value column set" do
+    thing = Thing.new
+    thing.width_value = 23
+    assert_nil thing.width
+  end
+
+  test "reader deals with only the _unit column set" do
+    thing = Thing.new
+    thing.width_unit = "cm"
+    assert_nil thing.width
+  end
+
+  test "reader deals with nil-ing out the _value column" do
+    thing.width_value = nil
+    assert_nil thing.width
+  end
+
+  test "reader deals with nil-ing out the _unit column" do
+    thing.width_unit = nil
+    assert_nil thing.width
+  end
+
+  test "writer sets the value to nil if it is an incompatible object" do
+    thing.length = Object.new
+    assert_nil thing.length
+  end
+
+  test "writer assigning nil blanks out the unit and value columns" do
+    thing.width = nil
+    assert_nil thing.width
+    assert_nil thing.width_unit
+    assert_nil thing.width_value
+  end
+
+  test "assigning an invalid _unit sets the column but the measurable object is nil" do
+    thing.width_unit = "invalid"
+    assert_nil thing.width
+    assert_equal "invalid", thing.width_unit
+  end
+
+  test "assigning a valid _unit sets it" do
+    thing.width_unit = :mm
+    assert_equal thing.width, Measured::Length.new(6, "mm")
+    assert_equal "mm", thing.width_unit
+  end
+
+  test "assigning a non-base unit to _unit converts it to its base unit" do
+    thing.width_unit = "millimetre"
+    assert_equal thing.width, Measured::Length.new(6, "mm")
+    assert_equal "mm", thing.width_unit
+  end
+
+  test "building a new object from attributes builds a measured object" do
+    thing = Thing.new(length_value: "30", length_unit: "m")
+    assert_equal Measured::Length.new(30, :m), thing.length
+  end
+
+  test "building a new object with a measured object assigns the properties" do
+    thing = Thing.new(length: new_length)
+    assert_equal new_length, thing.length
+    assert_equal 20, thing.length_value
+    assert_equal "in", thing.length_unit
+  end
+
+  test "assigning attributes updates the measured object" do
+    thing.attributes = {length_value: "30", length_unit: "m"}
+    assert_equal Measured::Length.new(30, :m), thing.length
+  end
+
+  test "assigning partial attributes updates the measured object" do
+    thing.attributes = {length_value: "30"}
+    assert_equal Measured::Length.new(30, :cm), thing.length
+  end
+
+  test "assigning the _unit leaves the _value unchanged" do
+    thing.total_weight_unit = :lb
+    assert_equal thing.total_weight, Measured::Weight.new(200, "lb")
+  end
+
+  test "assigning the _value leaves the _unit unchanged" do
+    thing.total_weight_value = "10"
+    assert_equal thing.total_weight, Measured::Weight.new(10, :g)
+  end
+
+  test "save persists the attributes and retrieves an object" do
+    thing = Thing.new length: Measured::Length.new(3, :m)
+    assert thing.save
+    assert_equal 3, thing.length_value
+    assert_equal "m", thing.length_unit
+    thing.reload
+    assert_equal 3, thing.length_value
+    assert_equal "m", thing.length_unit
+  end
+
+  test "save pulls attributes from assigned object" do
+    thing = Thing.new total_weight_value: "100", total_weight_unit: :lb
+    assert thing.save
+    thing.reload
+    assert_equal 100, thing.total_weight_value
+    assert_equal "lb", thing.total_weight_unit
+    assert_equal Measured::Weight.new(100, :lb), thing.total_weight
+  end
+
+  test "update_attribute sets only the _value column" do
+    thing = Thing.create!
+    thing.update_attribute(:width_value, 11)
+    assert_nil thing.width
+  end
+
+  test "update_attribute sets only the _unit column" do
+    thing = Thing.create!
+    thing.update_attribute(:width_unit, "cm")
+    assert_nil thing.width
+  end
+
+  test "update_attribute modifies the _value column" do
+    thing.update_attribute(:width_value, 99)
+    assert_equal Measured::Length.new(99, :in), thing.width
+  end
+
+  test "update_attribute modifies only the _unit column" do
+    thing.update_attribute(:width_unit, :cm)
+    assert_equal Measured::Length.new(6, :cm), thing.width
+  end
+
+  test "update_attribute sets one then the other" do
+    thing = Thing.create!
+    thing.update_attribute(:width_value, 11.1)
+    assert_nil thing.width
+    thing.update_attribute(:width_unit, "cm")
+    assert_equal Measured::Length.new(11.1, :cm), thing.width
+  end
+
+  test "update_attributes sets only the _value column" do
+    thing = Thing.create!
+    thing.update_attributes(width_value: "314")
+    assert_equal 314, thing.width_value
+    thing.reload
+    assert_equal 314, thing.width_value
+    assert_nil thing.width
+  end
+
+  test "update_attributes sets only the _unit column" do
+    thing = Thing.create!
+    thing.update_attributes(width_unit: :cm)
+    assert_equal "cm", thing.width_unit
+    thing.reload
+    assert_equal "cm", thing.width_unit
+    assert_nil thing.width
+  end
+
+  test "update_attributes sets only the _unit column and converts it" do
+    thing = Thing.create!
+    thing.update_attributes(width_unit: "inch")
+    assert_equal "in", thing.width_unit
+    thing.reload
+    assert_equal "in", thing.width_unit
+  end
+
+  test "update_attributes sets the _unit column to nonsense" do
+    thing = Thing.create!
+    thing.update_attributes(width_unit: "junk")
+    assert_equal "junk", thing.width_unit
+    thing.reload
+    assert_equal "junk", thing.width_unit
+  end
+
+  test "update_attributes sets one column then the other" do
+    thing = Thing.create!
+    thing.update_attributes(width_unit: "inch")
+    assert_nil thing.width
+    thing.update_attributes(width_value: "314")
+    assert_equal Measured::Length.new(314, :in), thing.width
+  end
+
+  test "update_attributes sets both columns" do
+    thing = Thing.create!
+    thing.update_attributes(width_unit: :cm, width_value: 2)
+    assert_equal Measured::Length.new(2, :cm), thing.width
+    thing.reload
+    assert_equal Measured::Length.new(2, :cm), thing.width
+  end
+
+  test "update_attributes modifies the _value column" do
+    thing.update_attributes(height_value: 2)
+    assert_equal Measured::Length.new(2, :m), thing.height
+    thing.reload
+    assert_equal Measured::Length.new(2, :m), thing.height
+  end
+
+  test "update_attributes modifies only the _unit column" do
+    thing.update_attributes(height_unit: "foot")
+    assert_equal Measured::Length.new(1, :ft), thing.height
+    thing.reload
+    assert_equal Measured::Length.new(1, :ft), thing.height
+  end
+
+  test "update_attributes modifies the _unit column to be something invalid" do
+    thing.update_attributes(height_unit: "junk")
+    assert_nil thing.height
+    assert_equal "junk", thing.height_unit
+    thing.reload
+    assert_nil thing.height
+    assert_equal "junk", thing.height_unit
+  end
+
+  test "update_attributes modifies both columns" do
+    thing.update_attributes(height_unit: "mm", height_value: 1.234)
+    assert_equal Measured::Length.new(1.234, :mm), thing.height
+    thing.reload
+    assert_equal Measured::Length.new(1.234, :mm), thing.height
+  end
+
+  private
+
+  def length
+    @length ||= Measured::Length.new(10, :cm)
+  end
+
+  def new_length
+    @new_length ||= Measured::Length.new(20, :in)
+  end
+
+  def thing
+    @thing ||= Thing.create!(
+      length: length,
+      width: Measured::Length.new(6, :in),
+      height: Measured::Length.new(1, :m),
+      total_weight: Measured::Weight.new(200, :g),
+      extra_weight: Measured::Weight.new(16, :oz)
+    )
   end
 end

--- a/test/dummy/app/models/thing.rb
+++ b/test/dummy/app/models/thing.rb
@@ -1,0 +1,11 @@
+class Thing < ActiveRecord::Base
+
+  measured_length :length, :width
+
+  measured Measured::Length, :height
+
+  measured_weight :total_weight
+
+  measured "Measured::Weight", :extra_weight
+
+end

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -1,0 +1,21 @@
+class ValidatedThing < ActiveRecord::Base
+
+  measured_length :length
+  validates :length, measured: true
+
+  measured_length :length_true
+  validates :length_true, measured: true
+
+  measured_length :length_message
+  validates :length_message, measured: {message: "has a custom failure message"}
+
+  measured_length :length_units
+  validates :length_units, measured: {units: [:meter, "cm"]}
+
+  measured_length :length_units_singular
+  validates :length_units_singular, measured: {units: :ft, message: "custom message too"}
+
+  measured_length :length_presence
+  validates :length_presence, measured: true, presence: true
+
+end

--- a/test/dummy/db/migrate/20150419151735_create_things.rb
+++ b/test/dummy/db/migrate/20150419151735_create_things.rb
@@ -1,0 +1,22 @@
+class CreateThings < ActiveRecord::Migration
+  def change
+    create_table :things do |t|
+      t.decimal :length_value, precision: 10, scale: 2
+      t.string :length_unit, limit: 12
+
+      t.decimal :width_value, precision: 10, scale: 2
+      t.string :width_unit, limit: 12
+
+      t.decimal :height_value, precision: 10, scale: 2
+      t.string :height_unit, limit: 12
+
+      t.decimal :total_weight_value, precision: 10, scale: 2, default: 10
+      t.string :total_weight_unit, limit: 12, default: "g"
+
+      t.decimal :extra_weight_value, precision: 10, scale: 2
+      t.string :extra_weight_unit, limit: 12
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20150419155505_create_validated_things.rb
+++ b/test/dummy/db/migrate/20150419155505_create_validated_things.rb
@@ -1,0 +1,29 @@
+class CreateValidatedThings < ActiveRecord::Migration
+  def change
+    create_table :validated_things do |t|
+
+      t.decimal :length_value, precision: 10, scale: 2
+      t.string :length_unit, limit: 12
+
+      t.decimal :length_true_value, precision: 10, scale: 2
+      t.string :length_true_unit, limit: 12
+
+      t.decimal :length_message_value, precision: 10, scale: 2
+      t.string :length_message_unit, limit: 12
+
+      t.decimal :length_units_value, precision: 10, scale: 2
+      t.string :length_units_unit, limit: 12
+
+      t.decimal :length_units_singular_value, precision: 10, scale: 2
+      t.string :length_units_singular_unit, limit: 12
+
+      t.decimal :length_presence_value, precision: 10, scale: 2
+      t.string :length_presence_unit, limit: 12
+
+      t.decimal :length_invalid_value, precision: 10, scale: 2
+      t.string :length_invalid_unit, limit: 12
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,50 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150419155505) do
+
+  create_table "things", force: :cascade do |t|
+    t.decimal  "length_value",                  precision: 10, scale: 2
+    t.string   "length_unit",        limit: 12
+    t.decimal  "width_value",                   precision: 10, scale: 2
+    t.string   "width_unit",         limit: 12
+    t.decimal  "height_value",                  precision: 10, scale: 2
+    t.string   "height_unit",        limit: 12
+    t.decimal  "total_weight_value",            precision: 10, scale: 2, default: 10.0
+    t.string   "total_weight_unit",  limit: 12,                          default: "g"
+    t.decimal  "extra_weight_value",            precision: 10, scale: 2
+    t.string   "extra_weight_unit",  limit: 12
+    t.datetime "created_at",                                                            null: false
+    t.datetime "updated_at",                                                            null: false
+  end
+
+  create_table "validated_things", force: :cascade do |t|
+    t.decimal  "length_value",                           precision: 10, scale: 2
+    t.string   "length_unit",                 limit: 12
+    t.decimal  "length_true_value",                      precision: 10, scale: 2
+    t.string   "length_true_unit",            limit: 12
+    t.decimal  "length_message_value",                   precision: 10, scale: 2
+    t.string   "length_message_unit",         limit: 12
+    t.decimal  "length_units_value",                     precision: 10, scale: 2
+    t.string   "length_units_unit",           limit: 12
+    t.decimal  "length_units_singular_value",            precision: 10, scale: 2
+    t.string   "length_units_singular_unit",  limit: 12
+    t.decimal  "length_presence_value",                  precision: 10, scale: 2
+    t.string   "length_presence_unit",        limit: 12
+    t.decimal  "length_invalid_value",                   precision: 10, scale: 2
+    t.string   "length_invalid_unit",         limit: 12
+    t.datetime "created_at",                                                      null: false
+    t.datetime "updated_at",                                                      null: false
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require "rails"
+require "rails/all"
 require "measured"
 require "measured-rails"
 require "minitest/autorun"
@@ -10,5 +10,12 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 ActiveSupport.test_order = :random
 
 class ActiveSupport::TestCase
-
+  def reset_db
+    ActiveRecord::Base.subclasses.each do |model|
+      model.delete_all
+    end
+  end
 end
+
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+load File.dirname(__FILE__) + '/dummy/db/schema.rb'

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class Measured::Rails::ValidationTest < ActiveSupport::TestCase
+  setup do
+    reset_db
+  end
+
+  test "validation measurable: validation leaves a model valid" do
+    assert Thing.new.valid?
+  end
+
+  test "validation true works by default" do
+    assert thing.valid?
+    thing.length_unit = "junk"
+    refute thing.valid?
+    assert_equal ["Length is not a valid unit"], thing.errors.full_messages
+  end
+
+  test "validation can override the message" do
+    assert thing.valid?
+    thing.length_message_unit = "junk"
+    refute thing.valid?
+    assert_equal ["Length message has a custom failure message"], thing.errors.full_messages
+  end
+
+  test "validation may be any valid unit" do
+    length_units.each do |unit|
+      thing.length_unit = unit
+      assert thing.valid?
+      thing.length_unit = unit.to_s
+      assert thing.valid?
+      thing.length = Measured::Length.new(123, unit)
+      assert thing.valid?
+    end
+  end
+
+  test "validation accepts a list of units in any format as an option and only allows them to be valid" do
+    thing.length_units_unit = :m
+    assert thing.valid?
+    thing.length_units_unit = :cm
+    assert thing.valid?
+    thing.length_units_unit = "cm"
+    assert thing.valid?
+    thing.length_units_unit = "meter"
+    assert thing.valid?
+    thing.length_units = Measured::Length.new(3, :cm)
+    assert thing.valid?
+    thing.length_units_unit = :mm
+    refute thing.valid?
+    thing.length_units = Measured::Length.new(3, :ft)
+    refute thing.valid?
+  end
+
+  test "validation lets the unit be singular" do
+    thing.length_units_singular_unit = :ft
+    assert thing.valid?
+    thing.length_units_singular_unit = "feet"
+    assert thing.valid?
+    thing.length_units_singular_unit = :mm
+    refute thing.valid?
+    thing.length_units_singular_unit = "meter"
+    refute thing.valid?
+  end
+
+  test "validation for unit reasons uses the default message" do
+    thing.length_units_unit = :mm
+    refute thing.valid?
+    assert_equal ["Length units is not a valid unit"], thing.errors.full_messages
+  end
+
+  test "validation for unit reasons also uses the custom message" do
+    thing.length_units_singular_unit = :mm
+    refute thing.valid?
+    assert_equal ["Length units singular custom message too"], thing.errors.full_messages
+  end
+
+  test "validation presence works on measured columns" do
+    assert thing.valid?
+    thing.length_presence = nil
+    refute thing.valid?
+    thing.length_presence_unit = "m"
+    refute thing.valid?
+    thing.length_presence_value = "3"
+    assert thing.valid?
+  end
+
+  private
+
+  def thing
+    @thing ||= ValidatedThing.new(
+      length: Measured::Length.new(1, :m),
+      length_true: Measured::Length.new(2, :cm),
+      length_message: Measured::Length.new(3, :mm),
+      length_units: Measured::Length.new(4, :m),
+      length_units_singular: Measured::Length.new(5, :ft),
+      length_presence: Measured::Length.new(6, :m)
+    )
+  end
+
+  def length_units
+    @length_units ||= [:m, :meter, :cm, :mm, :millimeter, :in, :ft, :feet, :yd]
+  end
+end


### PR DESCRIPTION
@Shopify/shipping @qq99 @patrickdonovan 

This implements the Rails/ActiveRecord adapter for the [measured](https://github.com/Shopify/measured) measurement gem.

It provides a mapping from the measurement to a `_value` and `_unit` column in the DB. It manages retrieval and storage, bulk updating, validations, and exception handling.

The best way to understand what this gem does is to read the new README:
https://github.com/Shopify/measured-rails/blob/initial-implementation/README.md

The diff looks big, but it's actually only a little over a hundred lines of feature code. The rest is tests, README, and gem scaffolding.