### PR TITLE
Add numericality validator options to measured

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,13 @@ Rather than `true` the validation can accept a hash with the following options:
 
 * `message`: Override the default "is invalid" message.
 * `units`: A subset of units available for this measurement. Units must be in existing measurement.
+* `greater_than`
+* `greater_than_or_equal_to`
+* `equal_to`
+* `less_than`
+* `less_than_or_equal_to`
 
-Validations can be combined with `presence` validator.
+Most of these options replace the `numericality` validator which compares the measurement/method name/proc to the column's value. Validations can also be combined with `presence` validator.
 
 **Note:** Validations are strongly recommended since assigning an invalid unit will cause the measurement to return `nil`, even if there is a value:
 

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -1,18 +1,53 @@
 class MeasuredValidator < ActiveModel::EachValidator
+  CHECKS = {
+    greater_than: :>,
+    greater_than_or_equal_to: :>=,
+    equal_to: :==,
+    less_than: :<,
+    less_than_or_equal_to: :<=,
+  }.freeze
+
   def validate_each(record, attribute, measurable)
     measured_config = record.class.measured_fields[attribute]
 
     measured_class = measured_config[:class]
-    measurable_unit = record.send("#{ attribute }_unit")
-    measurable_value = record.send("#{ attribute }_value")
+    measurable_unit = record.public_send("#{ attribute }_unit")
+    measurable_value = record.public_send("#{ attribute }_value")
 
-    message = options[:message] || "is not a valid unit"
+    return unless measurable_unit.present? || measurable_value.present?
+
+    record.errors.add(attribute, message) if [measurable_unit.blank?, measurable_value.blank?].any?
+
+    record.errors.add(attribute, message) unless measured_class.valid_unit?(measurable_unit)
 
     if options[:units]
       valid_units = [options[:units]].flatten.map{|u| measured_class.conversion.to_unit_name(u) }
       record.errors.add(attribute, message) unless valid_units.include?(measured_class.conversion.to_unit_name(measurable_unit))
     end
 
-    record.errors.add(attribute, message) unless measured_class.valid_unit?(measurable_unit)
+    options.slice(*CHECKS.keys).each do |option, value|
+      record.errors.add(attribute, message) unless measurable.public_send(CHECKS[option], value_for(value, record))
+    end
+  end
+
+  private
+
+  def message
+    options[:message] || "is not a valid unit"
+  end
+
+  def value_for(key, record)
+    value = case key
+    when Proc
+      key.call(record)
+    when Symbol
+      record.send(key)
+    else
+      key
+    end
+
+    raise ArgumentError, ":#{ value } must be a Measurable object" unless value.is_a?(Measured::Measurable)
+
+    value
   end
 end

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rails", ">= 4.0"
-  spec.add_runtime_dependency "measured", "0.0.4"
+  spec.add_runtime_dependency "measured", "0.0.6"
 
-  spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "mocha", "~> 1.1.0"

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -18,4 +18,26 @@ class ValidatedThing < ActiveRecord::Base
   measured_length :length_presence
   validates :length_presence, measured: true, presence: true
 
+  measured_length :length_numericality_inclusive
+  validates :length_numericality_inclusive, measured: {greater_than_or_equal_to: :low_bound, less_than_or_equal_to: :high_bound }
+
+  measured_length :length_numericality_exclusive
+  validates :length_numericality_exclusive, measured: {greater_than: Measured::Length.new(3, :m), less_than: Measured::Length.new(500, :cm), message: "is super not ok"}
+
+  measured_length :length_numericality_equality
+  validates :length_numericality_equality, measured: {equal_to: Proc.new { Measured::Length.new(100, :cm) }, message: "must be exactly 100cm"}
+
+  measured_length :length_invalid_comparison
+  validates :length_invalid_comparison, measured: {equal_to: "not_a_measured_subclass"}
+
+  private
+
+  def low_bound
+    Measured::Length.new(10, :in)
+  end
+
+  def high_bound
+    Measured::Length.new(20, :in)
+  end
+
 end

--- a/test/dummy/db/migrate/20150512214352_add_numericality.rb
+++ b/test/dummy/db/migrate/20150512214352_add_numericality.rb
@@ -1,0 +1,15 @@
+class AddNumericality < ActiveRecord::Migration
+  def change
+    add_column :validated_things, :length_numericality_inclusive_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_numericality_inclusive_unit, :string, limit: 12
+
+    add_column :validated_things, :length_numericality_exclusive_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_numericality_exclusive_unit, :string, limit: 12
+
+    add_column :validated_things, :length_numericality_equality_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_numericality_equality_unit, :string, limit: 12
+
+    add_column :validated_things, :length_invalid_comparison_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_invalid_comparison_unit, :string, limit: 12
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150419155505) do
+ActiveRecord::Schema.define(version: 20150512214352) do
 
   create_table "things", force: :cascade do |t|
     t.decimal  "length_value",                  precision: 10, scale: 2
@@ -29,22 +29,30 @@ ActiveRecord::Schema.define(version: 20150419155505) do
   end
 
   create_table "validated_things", force: :cascade do |t|
-    t.decimal  "length_value",                           precision: 10, scale: 2
-    t.string   "length_unit",                 limit: 12
-    t.decimal  "length_true_value",                      precision: 10, scale: 2
-    t.string   "length_true_unit",            limit: 12
-    t.decimal  "length_message_value",                   precision: 10, scale: 2
-    t.string   "length_message_unit",         limit: 12
-    t.decimal  "length_units_value",                     precision: 10, scale: 2
-    t.string   "length_units_unit",           limit: 12
-    t.decimal  "length_units_singular_value",            precision: 10, scale: 2
-    t.string   "length_units_singular_unit",  limit: 12
-    t.decimal  "length_presence_value",                  precision: 10, scale: 2
-    t.string   "length_presence_unit",        limit: 12
-    t.decimal  "length_invalid_value",                   precision: 10, scale: 2
-    t.string   "length_invalid_unit",         limit: 12
-    t.datetime "created_at",                                                      null: false
-    t.datetime "updated_at",                                                      null: false
+    t.decimal  "length_value",                                   precision: 10, scale: 2
+    t.string   "length_unit",                         limit: 12
+    t.decimal  "length_true_value",                              precision: 10, scale: 2
+    t.string   "length_true_unit",                    limit: 12
+    t.decimal  "length_message_value",                           precision: 10, scale: 2
+    t.string   "length_message_unit",                 limit: 12
+    t.decimal  "length_units_value",                             precision: 10, scale: 2
+    t.string   "length_units_unit",                   limit: 12
+    t.decimal  "length_units_singular_value",                    precision: 10, scale: 2
+    t.string   "length_units_singular_unit",          limit: 12
+    t.decimal  "length_presence_value",                          precision: 10, scale: 2
+    t.string   "length_presence_unit",                limit: 12
+    t.decimal  "length_invalid_value",                           precision: 10, scale: 2
+    t.string   "length_invalid_unit",                 limit: 12
+    t.datetime "created_at",                                                              null: false
+    t.datetime "updated_at",                                                              null: false
+    t.decimal  "length_numericality_inclusive_value",            precision: 10, scale: 2
+    t.string   "length_numericality_inclusive_unit",  limit: 12
+    t.decimal  "length_numericality_exclusive_value",            precision: 10, scale: 2
+    t.string   "length_numericality_exclusive_unit",  limit: 12
+    t.decimal  "length_numericality_equality_value",             precision: 10, scale: 2
+    t.string   "length_numericality_equality_unit",   limit: 12
+    t.decimal  "length_invalid_comparison_value",                precision: 10, scale: 2
+    t.string   "length_invalid_comparison_unit",      limit: 12
   end
 
 end


### PR DESCRIPTION
@Shopify/shipping 

Adds numericality validations on the ```measured``` fields to support numerical comparisons like ```<, ==, >, <=, >=``` as you'd expect. We can now validate ```measured``` fields in the model to be within certain pre-set bounds. Differences in units while doing bound validation checks also works. You can also set custom validation error messages for failing validations. 

For example, you can set a ```measured``` field called ```length``` in your model and create validations for it like, 
```ruby
measured_length :length
validates :length, measured: {greater_than: Measured::Length.new(3, :m), less_than: Measured::Length.new(500, :cm), message: "Custom validation error message"}
```

Validating against non-Measured fields raises an error. You can also pass ```Proc```s while valdiating
```ruby
measured_length :length
validates :length, measured: {equal_to: "Not a length"}
```

```ruby
measured_length :length
validates :length, measured: {equal_to: Proc.new { Measured::Length.new(100, :cm) }}
```
