### PR TITLE
Scalar validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Rather than `true` the validation can accept a hash with the following options:
 * `less_than`
 * `less_than_or_equal_to`
 
+**Special case** Comparison based validation against 0
+```ruby
+class Thing < ActiveRecord::Base
+  measured_length :non_negative_weight
+
+  validates :non_negative_weight, measured: {greater_than: 0}
+end
+```
+
 Most of these options replace the `numericality` validator which compares the measurement/method name/proc to the column's value. Validations can also be combined with `presence` validator.
 
 **Note:** Validations are strongly recommended since assigning an invalid unit will cause the measurement to return `nil`, even if there is a value:
@@ -123,3 +132,4 @@ $ bundle exec rake test
 ## Authors
 
 * [Kevin McPhillips](https://github.com/kmcphillips) at [Shopify](http://shopify.com/careers)
+* [Sai Warang](https://github.com/cyprusad) at [Shopify](http://shopify.com/careers)

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -46,6 +46,11 @@ class MeasuredValidator < ActiveModel::EachValidator
       key
     end
 
+    if value.is_a?(Fixnum)
+      raise ArgumentError, ":#{ value } is a scalar. Please validate against a Measurable object to add correct units" unless value == 0
+      return value
+    end
+
     raise ArgumentError, ":#{ value } must be a Measurable object" unless value.is_a?(Measured::Measurable)
 
     value

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -46,8 +46,8 @@ class MeasuredValidator < ActiveModel::EachValidator
       key
     end
 
-    if value.is_a?(Fixnum)
-      raise ArgumentError, ":#{ value } is a scalar. Please validate against a Measurable object to add correct units" unless value == 0
+    if value.is_a?(Numeric)
+      raise ArgumentError, ":#{ value } is a scalar. Please validate against a Measurable object with correct units" unless value == 0
       return value
     end
 

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rails", ">= 4.0"
-  spec.add_runtime_dependency "measured", "0.0.6"
+  spec.add_runtime_dependency "measured", "0.0.7"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -34,7 +34,7 @@ class ValidatedThing < ActiveRecord::Base
   validates :length_non_zero_scalar, measured: {equal_to: 4}
 
   measured_length :length_zero_scalar
-  validates :length_zero_scalar, measured: {greater_than: Measured::Length.new(0, :cm)}
+  validates :length_zero_scalar, measured: {greater_than: 0}
 
   private
 

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -30,6 +30,12 @@ class ValidatedThing < ActiveRecord::Base
   measured_length :length_invalid_comparison
   validates :length_invalid_comparison, measured: {equal_to: "not_a_measured_subclass"}
 
+  measured_length :length_non_zero_scalar
+  validates :length_non_zero_scalar, measured: {equal_to: 4}
+
+  measured_length :length_zero_scalar
+  validates :length_zero_scalar, measured: {greater_than: Measured::Length.new(0, :cm)}
+
   private
 
   def low_bound

--- a/test/dummy/db/migrate/20150512214352_add_numericality.rb
+++ b/test/dummy/db/migrate/20150512214352_add_numericality.rb
@@ -11,5 +11,11 @@ class AddNumericality < ActiveRecord::Migration
 
     add_column :validated_things, :length_invalid_comparison_value, :decimal, precision: 10, scale: 2
     add_column :validated_things, :length_invalid_comparison_unit, :string, limit: 12
+
+    add_column :validated_things, :length_non_zero_scalar_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_non_zero_scalar_unit, :string, limit: 12
+
+    add_column :validated_things, :length_zero_scalar_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_zero_scalar_unit, :string, limit: 12
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -53,6 +53,10 @@ ActiveRecord::Schema.define(version: 20150512214352) do
     t.string   "length_numericality_equality_unit",   limit: 12
     t.decimal  "length_invalid_comparison_value",                precision: 10, scale: 2
     t.string   "length_invalid_comparison_unit",      limit: 12
+    t.decimal  "length_non_zero_scalar_value",                   precision: 10, scale: 2
+    t.string   "length_non_zero_scalar_unit",         limit: 12
+    t.decimal  "length_zero_scalar_value",                       precision: 10, scale: 2
+    t.string   "length_zero_scalar_unit",             limit: 12
   end
 
 end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -103,15 +103,15 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
   end
 
   test "validation checks that numericality comparison against a scalar raise custom error" do
-    thing = ValidatedThing.new(length_non_zero_scalar: Measured::Length.new(4, :m))
+    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_non_zero_scalar: Measured::Length.new(4, :m))
     assert_raises ArgumentError, ":4 is a scalar. Please validate against a Measurable object to add correct units" do
-      thing.valid?
+      different_thing.valid?
     end
   end
 
   test "validation checks that numericality comparison against a zero value scalar works" do
-    thing = ValidatedThing.new(length_zero_scalar: Measured::Length.new(0.01, :cm))
-    thing.valid?
+    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_zero_scalar: Measured::Length.new(0.01, :cm))
+    assert different_thing.valid?
   end
 
   test "validation for numericality uses a default invalid message" do

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -102,6 +102,18 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     end
   end
 
+  test "validation checks that numericality comparison against a scalar raise custom error" do
+    thing = ValidatedThing.new(length_non_zero_scalar: Measured::Length.new(4, :m))
+    assert_raises ArgumentError, ":4 is a scalar. Please validate against a Measurable object to add correct units" do
+      thing.valid?
+    end
+  end
+
+  test "validation checks that numericality comparison against a zero value scalar works" do
+    thing = ValidatedThing.new(length_zero_scalar: Measured::Length.new(0.01, :cm))
+    thing.valid?
+  end
+
   test "validation for numericality uses a default invalid message" do
     thing.length_numericality_inclusive = Measured::Length.new(30, :in)
     refute thing.valid?


### PR DESCRIPTION
**Context**
Continuation of https://github.com/Shopify/measured/pull/12

Numericality validations are great for rails models. Moreover, it is likely that a lot of validations will be some sort of comparison against a zero valued ```Measured::Measurable``` object. Changes proposed in this PR make that particular case easy, since comparison against zero is a very natural thing to do and expecting to pass in the units of the zero value makes no sense.  i.e we should be able to compare against ```0``` and shouldn't have to specify the units, like ```Measured::Length(0, :cm)```

**Example**
```ruby
class AntiMatter < ActiveRecord::Base
  measured_weight :negative_weight

  validates :negative_weight, measured: {less_than: 0} ## as opposed to Measured::Weight(0, :kg)
end
```

Attempting numericalty comparison with any other scalar that is not zero continues to raise ```ArgumentError``` exceptions. This is just a special case handling of ```0```


cc @Shopify/shipping 
