### PR TITLE
Rounding the decimal value to the column's permitted rounding scale

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -42,7 +42,7 @@ module Measured::Rails::ActiveRecord
           if incoming.is_a?(measured_class)
             instance_variable_set("@measured_#{ field }", incoming)
             value_field_name = "#{ field }_value"
-            public_send("#{ value_field_name }=", incoming.value.round(self.column_for_attribute(value_field_name).precision))
+            public_send("#{ value_field_name }=", incoming.value.round(self.column_for_attribute(value_field_name).scale))
             public_send("#{ field }_unit=", incoming.unit)
           else
             instance_variable_set("@measured_#{ field }", nil)

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -275,14 +275,14 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal Measured::Length.new(1.234, :mm), thing.height
   end
 
-  test "assigning the _value with a BigDecimal rounds to the column's precision" do
+  test "assigning the _value with a BigDecimal rounds to the column's rounding scale" do
     thing.height = Measured::Length.new(BigDecimal.new('123.456789123455678'), :mm)
-    assert_equal thing.height_value, BigDecimal.new('123.4567891235')
+    assert_equal thing.height_value, BigDecimal.new('123.46')
   end
 
-  test "assigning the _value with a float uses all the precision available" do
+  test "assigning the _value with a float uses all the rounding scale permissible" do
     thing.height = Measured::Length.new(1234.456789123455678, :mm)
-    assert_equal thing.height_value, BigDecimal.new('1234.4567891235')
+    assert_equal thing.height_value, BigDecimal.new('1234.46')
   end
 
 

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -276,15 +276,20 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   test "assigning the _value with a BigDecimal rounds to the column's rounding scale" do
-    thing.height = Measured::Length.new(BigDecimal.new('123.456789123455678'), :mm)
-    assert_equal thing.height_value, BigDecimal.new('123.46')
+    thing.height = Measured::Length.new(BigDecimal.new('23.4567891'), :mm)
+    assert_equal thing.height_value, BigDecimal.new('23.46')
   end
 
   test "assigning the _value with a float uses all the rounding scale permissible" do
-    thing.height = Measured::Length.new(1234.456789123455678, :mm)
-    assert_equal thing.height_value, BigDecimal.new('1234.46')
+    thing.height = Measured::Length.new(4.45678912, :mm)
+    assert_equal thing.height_value, BigDecimal.new('4.46')
   end
 
+  test "assigning a number with more significant digits than permitted by the column precision raises exception" do
+    assert_raises Measured::Rails::Error, "The value 4.45678912123123123 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+      thing.height = Measured::Length.new(4.45678912123123123, :mm)
+    end
+  end
 
   private
 


### PR DESCRIPTION
So instead of rounding the number to the correct number of overall significant digits (i.e the column's precision) we are now rounding to the allowed scale (i.e permitted number of digits after the decimal point for a coumn)

This still leaves a bug where a number has total digits > column's precision as well as # of digits after decimal point > column's scale. Investigating how to get around this case.

For review @garethson @kmcphillips 