### PR TITLE
Round numbers before raising errors about numbers having large # of significant digits

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -44,11 +44,12 @@ module Measured::Rails::ActiveRecord
             value_field_name = "#{ field }_value"
             precision = self.column_for_attribute(value_field_name).precision
             scale = self.column_for_attribute(value_field_name).scale
+            rounded_to_scale_value = incoming.value.round(scale)
             ## For BigDecimal#split syntax, refer http://ruby-doc.org/stdlib-2.1.1/libdoc/bigdecimal/rdoc/BigDecimal.html#method-i-split
-            if incoming.value.split[1].size > precision
-              raise Measured::Rails::Error, "The value #{incoming.value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision} significant digits."
+            if rounded_to_scale_value.split[1].size > precision
+              raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision} significant digits."
             end
-            public_send("#{ value_field_name }=", incoming.value.round(scale))
+            public_send("#{ value_field_name }=", rounded_to_scale_value)
             public_send("#{ field }_unit=", incoming.unit)
           else
             instance_variable_set("@measured_#{ field }", nil)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -285,9 +285,16 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal thing.height_value, BigDecimal.new('4.46')
   end
 
-  test "assigning a number with more significant digits than permitted by the column precision raises exception" do
-    assert_raises Measured::Rails::Error, "The value 4.45678912123123123 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+  test "assigning a number with more significant digits than permitted by the column precision does not raise exception when it can be rounded to have lesser significant digits per column's scale" do
+    assert_nothing_raised Measured::Rails::Error do
       thing.height = Measured::Length.new(4.45678912123123123, :mm)
+      assert_equal thing.height_value, BigDecimal.new('4.46')
+    end
+  end
+
+  test "assigning a number with more significant digits than permitted by the column precision raises exception" do
+    assert_raises Measured::Rails::Error, "The value 44567891212312312.3 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+      thing.height = Measured::Length.new(44567891212312312.3, :mm)
     end
   end
 


### PR DESCRIPTION
@garethson @kmcphillips 

Round the number and only then raise if there are more significant digits than the column can handle.