### PR TITLE
Fix check for BigDecimal precision

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -45,8 +45,8 @@ module Measured::Rails::ActiveRecord
             precision = self.column_for_attribute(value_field_name).precision
             scale = self.column_for_attribute(value_field_name).scale
             rounded_to_scale_value = incoming.value.round(scale)
-            ## For BigDecimal#split syntax, refer http://ruby-doc.org/stdlib-2.1.1/libdoc/bigdecimal/rdoc/BigDecimal.html#method-i-split
-            if rounded_to_scale_value.split[1].size > precision
+            
+            if rounded_to_scale_value.to_s.length > precision
               raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision} significant digits."
             end
             public_send("#{ value_field_name }=", rounded_to_scale_value)

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -46,7 +46,7 @@ module Measured::Rails::ActiveRecord
             scale = self.column_for_attribute(value_field_name).scale
             rounded_to_scale_value = incoming.value.round(scale)
             
-            if rounded_to_scale_value.to_s.length > precision
+            if rounded_to_scale_value.to_i.to_s.length > (precision - scale)
               raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision} significant digits."
             end
             public_send("#{ value_field_name }=", rounded_to_scale_value)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -304,6 +304,20 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     end
   end
 
+  test "assigning a large number that's just smaller, equal to, and over the size of the column precision raises exception" do
+    assert_nothing_raised Measured::Rails::Error do
+      thing.height = Measured::Length.new(99999999.99, :mm)
+    end
+
+    assert_raises Measured::Rails::Error, "The value 100000000.0 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+      thing.height = Measured::Length.new(100000000, :mm)
+    end
+
+    assert_raises Measured::Rails::Error, "The value 100000000.01 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+      thing.height = Measured::Length.new(100000000.01, :mm)
+    end
+  end
+
   private
 
   def length

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -298,6 +298,12 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     end
   end
 
+  test "assigning a large number but with a small amount of significant digits than permitted by the column precision raises exception" do
+    assert_raises Measured::Rails::Error, "The value 2000000000000000.0 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
+      thing.height = Measured::Length.new(2_000_000_000_000_000, :mm)
+    end
+  end
+
   private
 
   def length


### PR DESCRIPTION
Our validation for column size had a small bug in that the check for precision could fail:
```
[1] pry(#<Thing>)> BigDecimal.new('2000000000000').split
=> [1, "2", 10, 13]
```
We then to "2".length which was < `precision` and our check failed us.

@trishume @kmcphillips 
