### PR TITLE
Allow numeric comparison against scalar.

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -27,6 +27,7 @@ class MeasuredValidator < ActiveModel::EachValidator
 
     options.slice(*CHECKS.keys).each do |option, value|
       comparable_value = value_for(value, record)
+      comparable_value = measured_class.new(comparable_value, measurable_unit) if comparable_value.is_a?(Numeric)
       unless measurable.public_send(CHECKS[option], comparable_value)
         record.errors.add(attribute, message("#{measurable.to_s} must be #{CHECKS[option]} #{comparable_value}"))
       end
@@ -48,14 +49,8 @@ class MeasuredValidator < ActiveModel::EachValidator
     else
       key
     end
-
-    if value.is_a?(Numeric)
-      raise ArgumentError, ":#{ value } is a scalar. Please validate against a Measurable object with correct units" unless value == 0
-      return value
-    end
-
-    raise ArgumentError, ":#{ value } must be a Measurable object" unless value.is_a?(Measured::Measurable)
-
+    
+    raise ArgumentError, ":#{ value } must be a number or a Measurable object" unless (value.is_a?(Numeric) || value.is_a?(Measured::Measurable))
     value
   end
 end

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -27,6 +27,9 @@ class ValidatedThing < ActiveRecord::Base
   measured_length :length_numericality_equality
   validates :length_numericality_equality, measured: {equal_to: Proc.new { Measured::Length.new(100, :cm) }, message: "must be exactly 100cm"}
 
+  measured_length :length_numericality_less_than_than_scalar
+  validates :length_numericality_less_than_than_scalar, measured: {less_than: 100}
+
   measured_length :length_invalid_comparison
   validates :length_invalid_comparison, measured: {equal_to: "not_a_measured_subclass"}
 

--- a/test/dummy/db/migrate/20152911214351_add_scalar_numericality_comparison.rb
+++ b/test/dummy/db/migrate/20152911214351_add_scalar_numericality_comparison.rb
@@ -1,0 +1,6 @@
+class AddNumericality < ActiveRecord::Migration
+  def change
+    add_column :validated_things, :length_numericality_less_than_than_scalar_value, :decimal, precision: 10, scale: 2
+    add_column :validated_things, :length_numericality_less_than_than_scalar_unit, :string, limit: 12
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20150512214352) do
     t.string   "length_non_zero_scalar_unit",         limit: 12
     t.decimal  "length_zero_scalar_value",                       precision: 10, scale: 2
     t.string   "length_zero_scalar_unit",             limit: 12
+    t.decimal  "length_numericality_less_than_than_scalar_value",                       precision: 10, scale: 2
+    t.string   "length_numericality_less_than_than_scalar_unit",             limit: 12
   end
 
 end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -103,15 +103,23 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     end
   end
 
-  test "validation checks that numericality comparison against a scalar raise custom error" do
+  test "validation checks that numericality comparison against a zero scalar works" do
     different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_non_zero_scalar: Measured::Length.new(4, :m))
-    assert_raises ArgumentError, ":4 is a scalar. Please validate against a Measurable object to add correct units" do
-      different_thing.valid?
-    end
+    different_thing.valid?
   end
 
   test "validation checks that numericality comparison against a zero value scalar works" do
     different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_zero_scalar: Measured::Length.new(0.01, :cm))
+    assert different_thing.valid?
+  end
+
+  test "validation checks that numericality comparison against non-zero scalar works" do
+    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_numericality_less_than_than_scalar: Measured::Length.new(100, :m))
+    refute different_thing.valid?
+  end
+
+  test "validation checks that numericality comparison against a scalar works" do
+    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_numericality_less_than_than_scalar: Measured::Length.new(99, :m))
     assert different_thing.valid?
   end
 


### PR DESCRIPTION
We currently don't support this in Shopify:
```ruby
 validates :length, :width, :height, measured: {greater_than: 0, less_than: 999999}
```
which causes us to have to change it to
```ruby
validates :length_value, :width_value, :height_value, numericality: {greater_than: 0, less_than: 999999, allow_nil: true}
```
which is unfortunate, as we loose our nice error messages and also expose the internals of `Measured` to the consuming interface.

I realize that enforcing a `less_than: X` on a Measurable field can seem strange, but in reality most of our use cases currently need to do this. The limits that software puts on fields is *usually* because of underlying storage constraints, not some real-world limit, like "over 100 lbs". This gives us the ability to still do both.

@cyprusad @kmcphillips @cyprusad 