### PR TITLE
Adds max_on_assignment option.

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -46,8 +46,11 @@ module Measured::Rails::ActiveRecord
             scale = self.column_for_attribute(value_field_name).scale
             rounded_to_scale_value = incoming.value.round(scale)
             
-            if rounded_to_scale_value.to_i.to_s.length > (precision - scale)
-              raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision} significant digits."
+            max = self.class.measured_fields[field][:max_on_assignment]
+            if max && rounded_to_scale_value > max
+              rounded_to_scale_value = max  
+            elsif rounded_to_scale_value.to_i.to_s.length > (precision - scale)
+              raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision - scale} significant digits."
             end
             public_send("#{ value_field_name }=", rounded_to_scale_value)
             public_send("#{ field }_unit=", incoming.unit)

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "0.0.9"
+    VERSION = "0.0.10"
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -37,7 +37,8 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
       width: { class: Measured::Length },
       height: { class: Measured::Length },
       total_weight: { class: Measured::Weight },
-      extra_weight: { class: Measured::Weight }
+      extra_weight: { class: Measured::Weight },
+      length_with_max_on_assignment: { max_on_assignment: 500, class: Measured::Length }
     }
 
     assert_equal expected, Thing.measured_fields
@@ -316,6 +317,16 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_raises Measured::Rails::Error, "The value 100000000.01 being set for column: 'height' has too many significant digits. Please ensure it has no more than 10 significant digits." do
       thing.height = Measured::Length.new(100000000.01, :mm)
     end
+  end
+
+  test "assigning a large number to a field that specifies max_on_assignment" do
+    thing = Thing.create!(length_with_max_on_assignment: Measured::Length.new(10000000000000000, :mm))
+    assert_equal Measured::Length.new(500, :mm), thing.length_with_max_on_assignment
+  end
+
+    test "assigning a small number to a field that specifies max_on_assignment" do
+    thing = Thing.create!(length_with_max_on_assignment: Measured::Length.new(1, :mm))
+    assert_equal Measured::Length.new(1, :mm), thing.length_with_max_on_assignment
   end
 
   private

--- a/test/dummy/app/models/thing.rb
+++ b/test/dummy/app/models/thing.rb
@@ -8,4 +8,6 @@ class Thing < ActiveRecord::Base
 
   measured "Measured::Weight", :extra_weight
 
+  measured_length :length_with_max_on_assignment, {max_on_assignment: 500}
+
 end

--- a/test/dummy/db/migrate/20150419151735_create_things.rb
+++ b/test/dummy/db/migrate/20150419151735_create_things.rb
@@ -16,6 +16,9 @@ class CreateThings < ActiveRecord::Migration
       t.decimal :extra_weight_value, precision: 10, scale: 2
       t.string :extra_weight_unit, limit: 12
 
+      t.decimal :length_with_max_on_assignment_value, precision: 10, scale: 2
+      t.string :length_with_max_on_assignment_unit, limit: 12
+
       t.timestamps null: false
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20150512214352) do
     t.string   "total_weight_unit",  limit: 12,                          default: "g"
     t.decimal  "extra_weight_value",            precision: 10, scale: 2
     t.string   "extra_weight_unit",  limit: 12
+    t.decimal  "length_with_max_on_assignment_value",            precision: 10, scale: 2
+    t.string   "length_with_max_on_assignment_unit",  limit: 12
     t.datetime "created_at",                                                            null: false
     t.datetime "updated_at",                                                            null: false
   end


### PR DESCRIPTION
Give the option of limiting the value on assignment to our measured fields. Since we enforce the database field size on assignment anyway, providing the option to always limit the value will remove a lot of code in the consuming Shopify code base that has to default these values to the max size the field can handle.

@kmcphillips @cyprusad @trishume 