### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "0.0.10"
+    VERSION = "1.1.0"
   end
 end

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rails", ">= 4.0"
-  spec.add_runtime_dependency "measured", "0.0.9"
+  spec.add_runtime_dependency "measured", "1.1.0"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"


### PR DESCRIPTION
@garethson 

Replaces #17. Bumps version to 1.1.0 to stay in line with https://github.com/Shopify/measured which is at the same version. Keep them in parallel to make versioning simple.