### PR TITLE
Improve tests around invalid units and saving

### DIFF
--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -147,6 +147,11 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal thing.total_weight, Measured::Weight.new(10, :g)
   end
 
+  test "assigning the _unit to an invalid unit does not raise" do
+    thing.total_weight_unit = :invalid
+    assert_nil thing.total_weight
+  end
+
   test "save persists the attributes and retrieves an object" do
     thing = Thing.new length: Measured::Length.new(3, :m)
     assert thing.save
@@ -166,6 +171,14 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal Measured::Weight.new(100, :lb), thing.total_weight
   end
 
+  test "save does not succeed if you assign an invalid unit" do
+    thing = Thing.new total_weight_value: "100", total_weight_unit: :invalid
+    assert thing.save
+    thing.reload
+    assert_nil thing.total_weight
+    assert_equal 100, thing.total_weight_value
+  end
+
   test "update_attribute sets only the _value column" do
     thing = Thing.create!
     thing.update_attribute(:width_value, 11)
@@ -179,26 +192,26 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   test "update_attribute modifies the _value column" do
-    thing.update_attribute(:width_value, 99)
+    assert thing.update_attribute(:width_value, 99)
     assert_equal Measured::Length.new(99, :in), thing.width
   end
 
   test "update_attribute modifies only the _unit column" do
-    thing.update_attribute(:width_unit, :cm)
+    assert thing.update_attribute(:width_unit, :cm)
     assert_equal Measured::Length.new(6, :cm), thing.width
   end
 
   test "update_attribute sets one then the other" do
     thing = Thing.create!
-    thing.update_attribute(:width_value, 11.1)
+    assert thing.update_attribute(:width_value, 11.1)
     assert_nil thing.width
-    thing.update_attribute(:width_unit, "cm")
+    assert thing.update_attribute(:width_unit, "cm")
     assert_equal Measured::Length.new(11.1, :cm), thing.width
   end
 
   test "update_attributes sets only the _value column" do
     thing = Thing.create!
-    thing.update_attributes(width_value: "314")
+    assert thing.update_attributes(width_value: "314")
     assert_equal 314, thing.width_value
     thing.reload
     assert_equal 314, thing.width_value
@@ -207,7 +220,7 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
 
   test "update_attributes sets only the _unit column" do
     thing = Thing.create!
-    thing.update_attributes(width_unit: :cm)
+    assert thing.update_attributes(width_unit: :cm)
     assert_equal "cm", thing.width_unit
     thing.reload
     assert_equal "cm", thing.width_unit
@@ -216,7 +229,7 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
 
   test "update_attributes sets only the _unit column and converts it" do
     thing = Thing.create!
-    thing.update_attributes(width_unit: "inch")
+    assert thing.update_attributes(width_unit: "inch")
     assert_equal "in", thing.width_unit
     thing.reload
     assert_equal "in", thing.width_unit
@@ -224,53 +237,54 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
 
   test "update_attributes sets the _unit column to nonsense" do
     thing = Thing.create!
-    thing.update_attributes(width_unit: "junk")
-    assert_equal "junk", thing.width_unit
+    assert thing.update_attributes(width_unit: :invalid)
+    assert_equal "invalid", thing.width_unit
     thing.reload
-    assert_equal "junk", thing.width_unit
+    assert_equal "invalid", thing.width_unit
+    assert_nil thing.width
   end
 
   test "update_attributes sets one column then the other" do
     thing = Thing.create!
-    thing.update_attributes(width_unit: "inch")
+    assert thing.update_attributes(width_unit: "inch")
     assert_nil thing.width
-    thing.update_attributes(width_value: "314")
+    assert thing.update_attributes(width_value: "314")
     assert_equal Measured::Length.new(314, :in), thing.width
   end
 
   test "update_attributes sets both columns" do
     thing = Thing.create!
-    thing.update_attributes(width_unit: :cm, width_value: 2)
+    assert thing.update_attributes(width_unit: :cm, width_value: 2)
     assert_equal Measured::Length.new(2, :cm), thing.width
     thing.reload
     assert_equal Measured::Length.new(2, :cm), thing.width
   end
 
   test "update_attributes modifies the _value column" do
-    thing.update_attributes(height_value: 2)
+    assert thing.update_attributes(height_value: 2)
     assert_equal Measured::Length.new(2, :m), thing.height
     thing.reload
     assert_equal Measured::Length.new(2, :m), thing.height
   end
 
   test "update_attributes modifies only the _unit column" do
-    thing.update_attributes(height_unit: "foot")
+    assert thing.update_attributes(height_unit: "foot")
     assert_equal Measured::Length.new(1, :ft), thing.height
     thing.reload
     assert_equal Measured::Length.new(1, :ft), thing.height
   end
 
   test "update_attributes modifies the _unit column to be something invalid" do
-    thing.update_attributes(height_unit: "junk")
+    assert thing.update_attributes(height_unit: :invalid)
     assert_nil thing.height
-    assert_equal "junk", thing.height_unit
+    assert_equal "invalid", thing.height_unit
     thing.reload
     assert_nil thing.height
-    assert_equal "junk", thing.height_unit
+    assert_equal "invalid", thing.height_unit
   end
 
   test "update_attributes modifies both columns" do
-    thing.update_attributes(height_unit: "mm", height_value: 1.23)
+    assert thing.update_attributes(height_unit: "mm", height_value: 1.23)
     assert_equal Measured::Length.new(1.23, :mm), thing.height
     thing.reload
     assert_equal Measured::Length.new(1.23, :mm), thing.height


### PR DESCRIPTION
@garethson @RichardBlair 

I'm chasing a `Measured::UnitError·Unit X does not exist` error. I thought it might be in measured (it's not) but I was not confident in our test coverage around this.

No functional changes. Just test improvements.