### PR TITLE
Do not error if unit is already known to be invalid

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -25,11 +25,13 @@ class MeasuredValidator < ActiveModel::EachValidator
       record.errors.add(attribute, message("is not a valid unit")) unless valid_units.include?(measured_class.conversion.to_unit_name(measurable_unit))
     end
 
-    options.slice(*CHECKS.keys).each do |option, value|
-      comparable_value = value_for(value, record)
-      comparable_value = measured_class.new(comparable_value, measurable_unit) if comparable_value.is_a?(Numeric)
-      unless measurable.public_send(CHECKS[option], comparable_value)
-        record.errors.add(attribute, message("#{measurable.to_s} must be #{CHECKS[option]} #{comparable_value}"))
+    if measured_class.valid_unit?(measurable_unit)
+      options.slice(*CHECKS.keys).each do |option, value|
+        comparable_value = value_for(value, record)
+        comparable_value = measured_class.new(comparable_value, measurable_unit) if comparable_value.is_a?(Numeric)
+        unless measurable.public_send(CHECKS[option], comparable_value)
+          record.errors.add(attribute, message("#{measurable.to_s} must be #{CHECKS[option]} #{comparable_value}"))
+        end
       end
     end
   end
@@ -49,7 +51,7 @@ class MeasuredValidator < ActiveModel::EachValidator
     else
       key
     end
-    
+
     raise ArgumentError, ":#{ value } must be a number or a Measurable object" unless (value.is_a?(Numeric) || value.is_a?(Measured::Measurable))
     value
   end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -194,6 +194,13 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_nil thing.length
   end
 
+  test "save fails if you assign an invalid unit and there is validation on numericality" do
+    thing = validated_thing
+    thing.length_zero_scalar_unit = "invalid"
+    refute thing.save
+    assert_nil thing.length_zero_scalar
+  end
+
   test "update_attribute sets only the _value column" do
     thing = Thing.create!
     thing.update_attribute(:width_value, 11)


### PR DESCRIPTION
@cyprusad @garethson @RichardBlair @mdking 

Found the bug. Follow up to #20.

If the unit is already known to be invalid, but there is a validation that _includes_ a numericality check we try to instantiate the measurement to do comparisons. But then that would raise.

So just skip the numericality checks if the unit is already known to be invalid. Can't do anything about it anyway.