### PR TITLE
Do not compare if the value is nil

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -25,7 +25,7 @@ class MeasuredValidator < ActiveModel::EachValidator
       record.errors.add(attribute, message("is not a valid unit")) unless valid_units.include?(measured_class.conversion.to_unit_name(measurable_unit))
     end
 
-    if measured_class.valid_unit?(measurable_unit)
+    if measured_class.valid_unit?(measurable_unit) && measurable_value.present?
       options.slice(*CHECKS.keys).each do |option, value|
         comparable_value = value_for(value, record)
         comparable_value = measured_class.new(comparable_value, measurable_unit) if comparable_value.is_a?(Numeric)

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -173,6 +173,18 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     refute thing.valid?
   end
 
+  test "validation for numericality handles a nil value but a valid unit" do
+    thing.length_numericality_exclusive_unit = :cm
+    thing.length_numericality_exclusive_value = nil
+    refute thing.valid?
+  end
+
+  test "validation for numericality handles a nil unit but a valid value" do
+    thing.length_numericality_exclusive_unit = nil
+    thing.length_numericality_exclusive_value = 1
+    refute thing.valid?
+  end
+
   private
 
   def thing


### PR DESCRIPTION
@cyprusad @garethson @RichardBlair

Another follow up bug fix for #21.

Don't do numericality checks if the value is `nil`. Happens when someone sends malformed request and basically does:

```ruby
thing.weight_value = nil
thing.weight_unit = :g
```

The unit is valid but then tries to compare the value of `nil` against the value in the validation.

Exception looks something like:

```
NoMethodError:         NoMethodError: undefined method `>' for nil:NilClass
            (measured-rails-1.3.1) lib/measured/rails/validations.rb:32 in `public_send`
            (measured-rails-1.3.1) lib/measured/rails/validations.rb:32 in `block in validate_each`
```