### PR TITLE
Stop validating presence

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -16,8 +16,6 @@ class MeasuredValidator < ActiveModel::EachValidator
 
     return unless measurable_unit.present? || measurable_value.present?
 
-    record.errors.add(attribute, message("cannot be blank")) if [measurable_unit.blank?, measurable_value.blank?].any?
-
     record.errors.add(attribute, message("is not a valid unit")) unless measured_class.valid_unit?(measurable_unit)
 
     if options[:units]

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -91,11 +91,6 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     refute thing.valid?
   end
 
-  test "validation fails if only if the unit is set" do
-    thing.length_value = nil
-    refute thing.valid?
-  end
-
   test "validation checks that numericality comparisons are against a Measurable subclass" do
     thing.length_invalid_comparison = Measured::Length.new(30, :in)
     assert_raises ArgumentError, ":not_a_measured_subclass must be a Measurable object" do
@@ -173,17 +168,17 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     refute thing.valid?
   end
 
-  test "validation for numericality handles a nil value but a valid unit" do
-    thing.length_numericality_exclusive_unit = :cm
-    thing.length_numericality_exclusive_value = nil
-    refute thing.valid?
-  end
-
   test "validation for numericality handles a nil unit but a valid value" do
     thing.length_numericality_exclusive_unit = nil
     thing.length_numericality_exclusive_value = 1
     refute thing.valid?
   end
+
+  test "allow a nil value but a valid unit" do
+    thing.length_numericality_exclusive_unit = :cm
+    thing.length_numericality_exclusive_value = nil
+    assert thing.valid?
+   end
 
   private
 


### PR DESCRIPTION
**Problems**
- We were validating presence wrong: when receiving multiple dimensions to validate at once, we were validating the first, and then quitting.
- Models using `measured` also validate presence via Rails, meaning the same validation is happening twice. This leads to duplicate errors when a validation fails.

**Solution**
Instead of fixing, we're removing validation logic from the gem, relying on Rails to validating presence. This will also resolve our duplicate error issues.

**Review**
Basically just deleted a bunch of code (and changed a test to now allow nil value since our models will be responsible for validating that). 