### PR TITLE
Add support for customizing the column holding the measured unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or stand alone:
 
 ### ActiveRecord
 
-Columns are expected to have the `_value` and `_unit` suffix, and be `DECIMAL` and `VARCHAR`, and defaults are accepted:
+Columns are expected to have the `_value` and `_unit` suffix, and be `DECIMAL` and `VARCHAR`, and defaults are accepted. Customizing the column used to hold units is supported, see below for details.
 
 ```ruby
 class AddWeightAndLengthToThings < ActiveRecord::Migration
@@ -40,6 +40,15 @@ A column can be declared as a measurement with its measurement subclass:
 class Thing < ActiveRecord::Base
   measured Measured::Weight, :minimum_weight
   measured Measured::Length, :total_length
+end
+```
+
+You can optionally customize the model's unit column by specifying it in the `unit_field_name` option, as follows:
+
+```ruby
+class ThingWithCustomUnitAccessor < ActiveRecord::Base
+  measured_length :length, :width, :height,     unit_field_name: :size_unit
+  measured_weight :total_weight, :extra_weight, unit_field_name: :weight_unit
 end
 ```
 

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -9,10 +9,13 @@ class MeasuredValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, measurable)
     measured_config = record.class.measured_fields[attribute]
+    unit_field_name = measured_config[:unit_field_name] || "#{ attribute }_unit"
+    value_field_name = "#{ attribute }_value"
 
     measured_class = measured_config[:class]
-    measurable_unit = record.public_send("#{ attribute }_unit")
-    measurable_value = record.public_send("#{ attribute }_value")
+
+    measurable_unit = record.public_send(unit_field_name)
+    measurable_value = record.public_send(value_field_name)
 
     return unless measurable_unit.present? || measurable_value.present?
 

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -366,9 +366,28 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal Measured::Length.new(500, :mm), thing.length_with_max_on_assignment
   end
 
-    test "assigning a small number to a field that specifies max_on_assignment" do
-    thing = Thing.create!(length_with_max_on_assignment: Measured::Length.new(1, :mm))
-    assert_equal Measured::Length.new(1, :mm), thing.length_with_max_on_assignment
+  test "assigning a small number to a field that specifies max_on_assignment" do
+     thing = Thing.create!(length_with_max_on_assignment: Measured::Length.new(1, :mm))
+     assert_equal Measured::Length.new(1, :mm), thing.length_with_max_on_assignment
+  end
+
+  test "using a similar unit accessor for multiple size fields" do
+    assert_equal Measured::Length.new(1, :m), custom_unit_thing.length
+    assert_equal Measured::Length.new(2, :m), custom_unit_thing.width
+    assert_equal Measured::Length.new(3, :m), custom_unit_thing.height
+    assert_equal Measured::Weight.new(10, :g), custom_unit_thing.total_weight
+    assert_equal Measured::Weight.new(12, :g), custom_unit_thing.extra_weight
+  end
+
+  test "changing unit value when shared affects all fields" do
+    custom_unit_thing.length = Measured::Length.new(15, :in)
+    custom_unit_thing.total_weight = Measured::Weight.new(42, :kg)
+
+    assert_equal custom_unit_thing.length, Measured::Length.new(15, :in)
+    assert_equal custom_unit_thing.width, Measured::Length.new(2, :in)
+    assert_equal custom_unit_thing.height, Measured::Length.new(3, :in)
+    assert_equal custom_unit_thing.total_weight, Measured::Weight.new(42, :kg)
+    assert_equal custom_unit_thing.extra_weight, Measured::Weight.new(12, :kg)
   end
 
   private
@@ -402,6 +421,16 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
       length_numericality_inclusive: Measured::Length.new(15, :in),
       length_numericality_exclusive: Measured::Length.new(4, :m),
       length_numericality_equality: Measured::Length.new(100, :cm),
+    )
+  end
+
+  def custom_unit_thing
+    @custom_unit_thing ||= ThingWithCustomUnitAccessor.new(
+      length: Measured::Length.new(1, :m),
+      width: Measured::Length.new(2, :m),
+      height: Measured::Length.new(3, :m),
+      total_weight: Measured::Weight.new(10, :g),
+      extra_weight: Measured::Weight.new(12, :g),
     )
   end
 end

--- a/test/dummy/app/models/thing_with_custom_unit_accessor.rb
+++ b/test/dummy/app/models/thing_with_custom_unit_accessor.rb
@@ -1,0 +1,15 @@
+class ThingWithCustomUnitAccessor < ActiveRecord::Base
+
+  measured_length :length, :width, unit_field_name: :size_unit
+  validates :length, measured: true
+  validates :width, measured: true
+
+  measured Measured::Length, :height, unit_field_name: :size_unit
+  validates :height, measured: true
+
+  measured_weight :total_weight, unit_field_name: :weight_unit
+  validates :total_weight, measured: true
+
+  measured "Measured::Weight", :extra_weight, unit_field_name: :weight_unit
+  validates :extra_weight, measured: true
+end

--- a/test/dummy/db/migrate/20152911214351_add_scalar_numericality_comparison.rb
+++ b/test/dummy/db/migrate/20152911214351_add_scalar_numericality_comparison.rb
@@ -1,4 +1,4 @@
-class AddNumericality < ActiveRecord::Migration
+class AddScalarNumericalityComparison < ActiveRecord::Migration
   def change
     add_column :validated_things, :length_numericality_less_than_than_scalar_value, :decimal, precision: 10, scale: 2
     add_column :validated_things, :length_numericality_less_than_than_scalar_unit, :string, limit: 12

--- a/test/dummy/db/migrate/20161118203701_create_thing_with_custom_unit_accessors.rb
+++ b/test/dummy/db/migrate/20161118203701_create_thing_with_custom_unit_accessors.rb
@@ -1,0 +1,18 @@
+class CreateThingWithCustomUnitAccessors < ActiveRecord::Migration[5.0]
+  def change
+    create_table :thing_with_custom_unit_accessors do |t|
+      t.decimal :length_value, precision: 10, scale: 2
+      t.decimal :width_value, precision: 10, scale: 2
+      t.decimal :height_value, precision: 10, scale: 2
+
+      t.string :size_unit, limit: 12
+
+      t.decimal :total_weight_value, precision: 10, scale: 2, default: 10
+      t.decimal :extra_weight_value, precision: 10, scale: 2
+
+      t.string :weight_unit, limit: 12
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,56 +10,68 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512214352) do
+ActiveRecord::Schema.define(version: 20161118203701) do
+
+  create_table "thing_with_custom_unit_accessors", force: :cascade do |t|
+    t.decimal  "length_value",                  precision: 10, scale: 2
+    t.decimal  "width_value",                   precision: 10, scale: 2
+    t.decimal  "height_value",                  precision: 10, scale: 2
+    t.string   "size_unit",          limit: 12
+    t.decimal  "total_weight_value",            precision: 10, scale: 2, default: "10.0"
+    t.decimal  "extra_weight_value",            precision: 10, scale: 2
+    t.string   "weight_unit",        limit: 12
+    t.datetime "created_at",                                                              null: false
+    t.datetime "updated_at",                                                              null: false
+  end
 
   create_table "things", force: :cascade do |t|
-    t.decimal  "length_value",                  precision: 10, scale: 2
-    t.string   "length_unit",        limit: 12
-    t.decimal  "width_value",                   precision: 10, scale: 2
-    t.string   "width_unit",         limit: 12
-    t.decimal  "height_value",                  precision: 10, scale: 2
-    t.string   "height_unit",        limit: 12
-    t.decimal  "total_weight_value",            precision: 10, scale: 2, default: 10.0
-    t.string   "total_weight_unit",  limit: 12,                          default: "g"
-    t.decimal  "extra_weight_value",            precision: 10, scale: 2
-    t.string   "extra_weight_unit",  limit: 12
+    t.decimal  "length_value",                                   precision: 10, scale: 2
+    t.string   "length_unit",                         limit: 12
+    t.decimal  "width_value",                                    precision: 10, scale: 2
+    t.string   "width_unit",                          limit: 12
+    t.decimal  "height_value",                                   precision: 10, scale: 2
+    t.string   "height_unit",                         limit: 12
+    t.decimal  "total_weight_value",                             precision: 10, scale: 2, default: "10.0"
+    t.string   "total_weight_unit",                   limit: 12,                          default: "g"
+    t.decimal  "extra_weight_value",                             precision: 10, scale: 2
+    t.string   "extra_weight_unit",                   limit: 12
     t.decimal  "length_with_max_on_assignment_value",            precision: 10, scale: 2
     t.string   "length_with_max_on_assignment_unit",  limit: 12
-    t.datetime "created_at",                                                            null: false
-    t.datetime "updated_at",                                                            null: false
+    t.datetime "created_at",                                                                               null: false
+    t.datetime "updated_at",                                                                               null: false
   end
 
   create_table "validated_things", force: :cascade do |t|
-    t.decimal  "length_value",                                   precision: 10, scale: 2
-    t.string   "length_unit",                         limit: 12
-    t.decimal  "length_true_value",                              precision: 10, scale: 2
-    t.string   "length_true_unit",                    limit: 12
-    t.decimal  "length_message_value",                           precision: 10, scale: 2
-    t.string   "length_message_unit",                 limit: 12
-    t.decimal  "length_units_value",                             precision: 10, scale: 2
-    t.string   "length_units_unit",                   limit: 12
-    t.decimal  "length_units_singular_value",                    precision: 10, scale: 2
-    t.string   "length_units_singular_unit",          limit: 12
-    t.decimal  "length_presence_value",                          precision: 10, scale: 2
-    t.string   "length_presence_unit",                limit: 12
-    t.decimal  "length_invalid_value",                           precision: 10, scale: 2
-    t.string   "length_invalid_unit",                 limit: 12
-    t.datetime "created_at",                                                              null: false
-    t.datetime "updated_at",                                                              null: false
-    t.decimal  "length_numericality_inclusive_value",            precision: 10, scale: 2
-    t.string   "length_numericality_inclusive_unit",  limit: 12
-    t.decimal  "length_numericality_exclusive_value",            precision: 10, scale: 2
-    t.string   "length_numericality_exclusive_unit",  limit: 12
-    t.decimal  "length_numericality_equality_value",             precision: 10, scale: 2
-    t.string   "length_numericality_equality_unit",   limit: 12
-    t.decimal  "length_invalid_comparison_value",                precision: 10, scale: 2
-    t.string   "length_invalid_comparison_unit",      limit: 12
-    t.decimal  "length_non_zero_scalar_value",                   precision: 10, scale: 2
-    t.string   "length_non_zero_scalar_unit",         limit: 12
-    t.decimal  "length_zero_scalar_value",                       precision: 10, scale: 2
-    t.string   "length_zero_scalar_unit",             limit: 12
-    t.decimal  "length_numericality_less_than_than_scalar_value",                       precision: 10, scale: 2
-    t.string   "length_numericality_less_than_than_scalar_unit",             limit: 12
+    t.decimal  "length_value",                                               precision: 10, scale: 2
+    t.string   "length_unit",                                     limit: 12
+    t.decimal  "length_true_value",                                          precision: 10, scale: 2
+    t.string   "length_true_unit",                                limit: 12
+    t.decimal  "length_message_value",                                       precision: 10, scale: 2
+    t.string   "length_message_unit",                             limit: 12
+    t.decimal  "length_units_value",                                         precision: 10, scale: 2
+    t.string   "length_units_unit",                               limit: 12
+    t.decimal  "length_units_singular_value",                                precision: 10, scale: 2
+    t.string   "length_units_singular_unit",                      limit: 12
+    t.decimal  "length_presence_value",                                      precision: 10, scale: 2
+    t.string   "length_presence_unit",                            limit: 12
+    t.decimal  "length_invalid_value",                                       precision: 10, scale: 2
+    t.string   "length_invalid_unit",                             limit: 12
+    t.datetime "created_at",                                                                          null: false
+    t.datetime "updated_at",                                                                          null: false
+    t.decimal  "length_numericality_inclusive_value",                        precision: 10, scale: 2
+    t.string   "length_numericality_inclusive_unit",              limit: 12
+    t.decimal  "length_numericality_exclusive_value",                        precision: 10, scale: 2
+    t.string   "length_numericality_exclusive_unit",              limit: 12
+    t.decimal  "length_numericality_equality_value",                         precision: 10, scale: 2
+    t.string   "length_numericality_equality_unit",               limit: 12
+    t.decimal  "length_invalid_comparison_value",                            precision: 10, scale: 2
+    t.string   "length_invalid_comparison_unit",                  limit: 12
+    t.decimal  "length_non_zero_scalar_value",                               precision: 10, scale: 2
+    t.string   "length_non_zero_scalar_unit",                     limit: 12
+    t.decimal  "length_zero_scalar_value",                                   precision: 10, scale: 2
+    t.string   "length_zero_scalar_unit",                         limit: 12
+    t.decimal  "length_numericality_less_than_than_scalar_value",            precision: 10, scale: 2
+    t.string   "length_numericality_less_than_than_scalar_unit",  limit: 12
   end
 
 end


### PR DESCRIPTION
**Problem**

With the current implementation of measured-rails, we need a separate column to hold the units of each declared field. Sometimes you might want to just use the same column to hold these units, but this is not possible.

**Solution**

I'm suggesting that we add an option when declaring `measured_length` and `measured_weight`: `unit_column_name`. This tells measured-rails which field it should read the unit from.

**Sample usage**

```ruby
class ThingWithCustomUnitAccessor < ActiveRecord::Base
  measured_length :length, :width, :height,      unit_column_name: :size_unit
  measured_weight :total_weight, :extra_weight, unit_column_name: :weight_unit
end
```

CR: @kmcphillips @MalazAlamir 