### PR TITLE
Explicitly lock to measured version

### DIFF
--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "measured", Measured::Rails::VERSION
+
   spec.add_runtime_dependency "railties", ">= 4.0"
   spec.add_runtime_dependency "activemodel", ">= 4.0"
-  spec.add_runtime_dependency "measured", "1.5.0"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"


### PR DESCRIPTION
@benwah @jonathankwok 

We keep `measured` and `measured-rails` at the same version. Even if it means releasing empty versions to keep them in sync. Much clearer way to understand how the versions interact and their dependencies.

Make this explicit in the gemspec. Don't let the release person forget to update the dependency. 