### PR TITLE
This addresses a bug where we use the wrong setter when assigning a Measured instance to a measured_field using a custom unit field

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -13,13 +13,15 @@ module Measured::Rails::ActiveRecord
 
       options[:class] = measured_class
 
+      custom_unit_field_name = options[:unit_field_name].to_s.presence
+
       fields.map(&:to_sym).each do |field|
         raise Measured::Rails::Error, "The field #{ field } has already been measured" if measured_fields.keys.include?(field)
 
         measured_fields[field] = options
 
-        if options[:unit_field_name]
-          unit_field_name = options[:unit_field_name].to_s
+        if custom_unit_field_name
+          unit_field_name = custom_unit_field_name
           measured_fields[field][:unit_field_name] = unit_field_name
         else
           unit_field_name = "#{ field }_unit"

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -380,14 +380,19 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   test "changing unit value when shared affects all fields" do
-    custom_unit_thing.length = Measured::Length.new(15, :in)
+    custom_unit_thing.width = Measured::Length.new(15, :in)
     custom_unit_thing.total_weight = Measured::Weight.new(42, :kg)
 
-    assert_equal custom_unit_thing.length, Measured::Length.new(15, :in)
-    assert_equal custom_unit_thing.width, Measured::Length.new(2, :in)
+    assert_equal custom_unit_thing.length, Measured::Length.new(1, :in)
+    assert_equal custom_unit_thing.width, Measured::Length.new(15, :in)
     assert_equal custom_unit_thing.height, Measured::Length.new(3, :in)
     assert_equal custom_unit_thing.total_weight, Measured::Weight.new(42, :kg)
     assert_equal custom_unit_thing.extra_weight, Measured::Weight.new(12, :kg)
+
+    custom_unit_thing.length = Measured::Length.new(15, :in)
+    assert_equal custom_unit_thing.length, Measured::Length.new(15, :in)
+    assert_equal custom_unit_thing.width, Measured::Length.new(15, :in)
+    assert_equal custom_unit_thing.height, Measured::Length.new(3, :in)
   end
 
   private


### PR DESCRIPTION
I introduced a bug affecting `measured` fields using a custom unit accessor. This PR resolves the bug. Will bump to 1.6.1.

I wasn't using the correct accessor for `<foo>_unit` fields.

CR: @kmcphillips @jonathankwok 