### PR TITLE
Explicitly support 4.2 and up only

### DIFF
--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "measured", Measured::Rails::VERSION
 
-  spec.add_runtime_dependency "railties", ">= 4.0"
-  spec.add_runtime_dependency "activemodel", ">= 4.0"
+  spec.add_runtime_dependency "railties", ">= 4.2"
+  spec.add_runtime_dependency "activemodel", ">= 4.2"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"


### PR DESCRIPTION
@benwah @thegedge 

Closes #30

We only run tests on Rails 4.2 and up, and those are the only currently supported versions of Rails.

Related to https://github.com/Shopify/measured/pull/43