### PR TITLE
Test with ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.1
+  - 2.4.0
 gemfile:
   - Gemfile
   - gemfiles/rails-4.2.gemfile
@@ -15,3 +16,5 @@ matrix:
       rvm: 2.1.8
     - gemfile: gemfiles/rails-master.gemfile
       rvm: 2.1.8
+    - gemfile: gemfiles/rails-4.2.gemfile
+      rvm: 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ matrix:
       rvm: 2.1.8
     - gemfile: gemfiles/rails-4.2.gemfile
       rvm: 2.4.0
+  allow_failures:
+    - gemfile: gemfiles/rails-master.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/rails-4.2.gemfile
+  - gemfiles/rails-5.0.gemfile
   - gemfiles/rails-master.gemfile
 matrix:
   exclude:
     - gemfile: Gemfile
       rvm: 2.1.8
     - gemfile: gemfiles/rails-master.gemfile
+      rvm: 2.1.8
+    - gemfile: gemfiles/rails-5.0.gemfile
       rvm: 2.1.8
     - gemfile: gemfiles/rails-4.2.gemfile
       rvm: 2.4.0

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.0'


### PR DESCRIPTION
Include Ruby 2.4.0 in our CI list. Skip Rails 4.2 as there is a JSON version conflict.

Related to https://github.com/Shopify/measured/pull/56