### PR TITLE
Bump version to 2.0.0.pre4

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This will allow you to access and assign a measurement object:
 ```ruby
 thing = Thing.new
 thing.minimum_weight = Measured::Weight.new(10, "g")
-thing.minimum_weight_unit      # "g"
+thing.minimum_weight_unit     # "g"
 thing.minimum_weight_value    # 10
 ```
 
@@ -75,7 +75,7 @@ Order of assignment does not matter, and each property can be assigned separatel
 ```ruby
 params = { total_length_unit: "cm", total_length_value: "3" }
 thing = Thing.new(params)
-thing.total_length   # #<Measured::Length: 3 cm>
+thing.total_length.to_s   # 3 cm
 ```
 
 ### Validations
@@ -102,16 +102,7 @@ Rather than `true` the validation can accept a hash with the following options:
 * `less_than`
 * `less_than_or_equal_to`
 
-**Special case** Comparison based validation against 0
-```ruby
-class Thing < ActiveRecord::Base
-  measured_length :non_negative_weight
-
-  validates :non_negative_weight, measured: {greater_than: 0}
-end
-```
-
-Most of these options replace the `numericality` validator which compares the measurement/method name/proc to the column's value. Validations can also be combined with `presence` validator.
+All comparison validations require `Measured::Measurable` values, not scalars. Most of these options replace the `numericality` validator which compares the measurement/method name/proc to the column's value. Validations can also be combined with `presence` validator.
 
 **Note:** Validations are strongly recommended since assigning an invalid unit will cause the measurement to return `nil`, even if there is a value:
 
@@ -120,9 +111,7 @@ thing = Thing.new
 thing.total_length_value = 1
 thing.total_length_unit = "invalid"
 thing.total_length  # nil
-
 ```
-
 
 ## Tests
 

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -8,21 +8,21 @@ module Measured::Rails::ActiveRecord
       defined_unit_accessors = []
 
       measured_class = measured_class.constantize if measured_class.is_a?(String)
-
-      raise Measured::Rails::Error, "Expecting #{ measured_class } to be a subclass of Measured::Measurable" if !measured_class.is_a?(Class) || !measured_class.ancestors.include?(Measured::Measurable)
+      unless measured_class.is_a?(Class) && measured_class.ancestors.include?(Measured::Measurable)
+        raise Measured::Rails::Error, "Expecting #{ measured_class } to be a subclass of Measured::Measurable"
+      end
 
       options[:class] = measured_class
 
       fields.map(&:to_sym).each do |field|
-        raise Measured::Rails::Error, "The field #{ field } has already been measured" if measured_fields.keys.include?(field)
+        raise Measured::Rails::Error, "The field #{ field } has already been measured" if measured_fields.key?(field)
 
         measured_fields[field] = options
 
-        if options[:unit_field_name]
-          unit_field_name = options[:unit_field_name].to_s
-          measured_fields[field][:unit_field_name] = unit_field_name
+        unit_field_name = if options[:unit_field_name]
+          measured_fields[field][:unit_field_name] = options[:unit_field_name].to_s
         else
-          unit_field_name = "#{ field }_unit"
+          "#{ field }_unit"
         end
 
         value_field_name = "#{ field }_value"
@@ -41,7 +41,7 @@ module Measured::Rails::ActiveRecord
             nil
           end
 
-          if instance && instance == new_instance
+          if instance == new_instance
             instance
           else
             instance_variable_set("@measured_#{ field }", new_instance)
@@ -58,12 +58,13 @@ module Measured::Rails::ActiveRecord
 
             max = self.class.measured_fields[field][:max_on_assignment]
             if max && rounded_to_scale_value > max
-              rounded_to_scale_value = max  
+              rounded_to_scale_value = max
             elsif rounded_to_scale_value.to_i.to_s.length > (precision - scale)
               raise Measured::Rails::Error, "The value #{rounded_to_scale_value} being set for column '#{value_field_name}' has too many significant digits. Please ensure it has no more than #{precision - scale} significant digits."
             end
+
             public_send("#{ value_field_name }=", rounded_to_scale_value)
-            public_send("#{ unit_field_name }=", incoming.unit)
+            public_send("#{ unit_field_name }=", incoming.unit.name)
           else
             instance_variable_set("@measured_#{ field }", nil)
             public_send("#{ value_field_name}=", nil)
@@ -76,8 +77,8 @@ module Measured::Rails::ActiveRecord
         # Writer to override unit assignment
         define_method("#{ unit_field_name }=") do |incoming|
           defined_unit_accessors << unit_field_name
-          incoming = measured_class.conversion.to_unit_name(incoming) if measured_class.valid_unit?(incoming)
-          write_attribute(unit_field_name, incoming)
+          unit_name = measured_class.unit_system.unit_for(incoming).try!(:name)
+          write_attribute(unit_field_name, unit_name || incoming)
         end
       end
     end

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "2.0.0.pre3"
+    VERSION = "2.0.0.pre4"
   end
 end

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "1.6.0"
+    VERSION = "2.0.0.pre3"
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -194,13 +194,6 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_nil thing.length
   end
 
-  test "save fails if you assign an invalid unit and there is validation on numericality" do
-    thing = validated_thing
-    thing.length_zero_scalar_unit = "invalid"
-    refute thing.save
-    assert_nil thing.length_zero_scalar
-  end
-
   test "update_attribute sets only the _value column" do
     thing = Thing.create!
     thing.update_attribute(:width_value, 11)

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -27,17 +27,8 @@ class ValidatedThing < ActiveRecord::Base
   measured_length :length_numericality_equality
   validates :length_numericality_equality, measured: {equal_to: Proc.new { Measured::Length.new(100, :cm) }, message: "must be exactly 100cm"}
 
-  measured_length :length_numericality_less_than_than_scalar
-  validates :length_numericality_less_than_than_scalar, measured: {less_than: 100}
-
   measured_length :length_invalid_comparison
   validates :length_invalid_comparison, measured: {equal_to: "not_a_measured_subclass"}
-
-  measured_length :length_non_zero_scalar
-  validates :length_non_zero_scalar, measured: {equal_to: 4}
-
-  measured_length :length_zero_scalar
-  validates :length_zero_scalar, measured: {greater_than: 0}
 
   private
 

--- a/test/dummy/db/migrate/20170201223955_remove_scalar_fields.rb
+++ b/test/dummy/db/migrate/20170201223955_remove_scalar_fields.rb
@@ -1,0 +1,12 @@
+class RemoveScalarFields < ActiveRecord::Migration
+  def change
+    remove_column :validated_things, :length_numericality_less_than_than_scalar_value
+    remove_column :validated_things, :length_numericality_less_than_than_scalar_unit
+
+    remove_column :validated_things, :length_non_zero_scalar_value
+    remove_column :validated_things, :length_non_zero_scalar_unit
+
+    remove_column :validated_things, :length_zero_scalar_value
+    remove_column :validated_things, :length_zero_scalar_unit
+  end
+end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -117,26 +117,6 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     end
   end
 
-  test "validation checks that numericality comparison against a zero scalar works" do
-    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_non_zero_scalar: Measured::Length.new(4, :m))
-    different_thing.valid?
-  end
-
-  test "validation checks that numericality comparison against a zero value scalar works" do
-    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_zero_scalar: Measured::Length.new(0.01, :cm))
-    assert different_thing.valid?
-  end
-
-  test "validation checks that numericality comparison against non-zero scalar works" do
-    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_numericality_less_than_than_scalar: Measured::Length.new(100, :m))
-    refute different_thing.valid?
-  end
-
-  test "validation checks that numericality comparison against a scalar works" do
-    different_thing = ValidatedThing.new(length_presence: Measured::Length.new(4, :m), length_numericality_less_than_than_scalar: Measured::Length.new(99, :m))
-    assert different_thing.valid?
-  end
-
   test "validation for numericality uses a default invalid message" do
     thing.length_numericality_inclusive = Measured::Length.new(30, :in)
     refute thing.valid?


### PR DESCRIPTION
Bringing `measured-rails` in line with the prerelease of `measured`, which focused on correctness and performance.

The two biggest changes here would be:

1. the removal of scalars for comparisons, and
2. return `Measured::Unit` instances for `Measurable#unit`, which requires us to generally call `Unit#name` to get the same result (since `Measurable#unit` was the unit name previously).