### PR TITLE
Add minitest reporters and update gems

### DIFF
--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -23,9 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "railties", ">= 4.2"
   spec.add_runtime_dependency "activemodel", ">= 4.2"
 
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.5.1"
-  spec.add_development_dependency "mocha", "~> 1.1.0"
+  spec.add_development_dependency "rake", "> 10.0"
+  spec.add_development_dependency "minitest", "> 5.5.1"
+  spec.add_development_dependency "minitest-reporters"
+  spec.add_development_dependency "mocha", "> 1.1.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "sqlite3"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,15 @@ require "rails/all"
 require "measured"
 require "measured-rails"
 require "minitest/autorun"
+require "minitest/reporters"
 require "mocha/setup"
 require "pry"
 
 require File.expand_path("../dummy/config/environment", __FILE__)
 
 ActiveSupport.test_order = :random
+
+Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new(color: true)]
 
 class ActiveSupport::TestCase
   def reset_db


### PR DESCRIPTION
Adds `minitest-reporters` and unsticks us from old test versions.

Related to https://github.com/Shopify/measured/pull/82

![kevin_kevify____source_measured-rails__zsh_](https://cloud.githubusercontent.com/assets/84159/23234655/c2545762-f920-11e6-852d-3af87c0851d6.png)
