### PR TITLE
Remove deprecated option

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -27,8 +27,5 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
### Problem

When we run `bundle exec rake test` we run into the following problem:
```
➜  measured-rails git:(master) bundle exec rake test
/opt/rubies/2.3.1/bin/ruby -w -I"lib:test:lib/**/*" -I"/Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib" "/Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/active_record_test.rb" "test/validation_test.rb"
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `raise_in_transactional_callbacks=' for ActiveRecord::Base:Class (NoMethodError)
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/railtie.rb:112:in `block (3 levels) in <class:Railtie>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/railtie.rb:111:in `each'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/railtie.rb:111:in `block (2 levels) in <class:Railtie>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:45:in `instance_eval'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:45:in `execute_hook'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:51:in `each'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/base.rb:326:in `<module:ActiveRecord>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activerecord-5.1.3/lib/active_record/base.rb:25:in `<top (required)>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `require'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `block in require'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:258:in `load_dependency'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `require'
	from /Users/lucasuyezu/src/github.com/Shopify/measured-rails/test/test_helper.rb:23:in `<top (required)>'
	from /Users/lucasuyezu/src/github.com/Shopify/measured-rails/test/active_record_test.rb:1:in `require'
	from /Users/lucasuyezu/src/github.com/Shopify/measured-rails/test/active_record_test.rb:1:in `<top (required)>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test:lib/**/*" -I"/Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib" "/Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/active_record_test.rb" "test/validation_test.rb" ]
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `load'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:27:in `run'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli.rb:362:in `exec'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli.rb:22:in `dispatch'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/cli.rb:13:in `start'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/exe/bundle:30:in `block in <top (required)>'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/lucasuyezu/.gem/ruby/2.3.1/gems/bundler-1.15.4/exe/bundle:22:in `<top (required)>'
/Users/lucasuyezu/.gem/ruby/2.3.1/bin/bundle:23:in `load'
/Users/lucasuyezu/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

This happens because the dependencies are listed as `> 4.2`. Rails 5 removed the `raise_in_transactional_callbacks` options with no replacement.

### Solution
Remove the deprecated option.

cc @mdking @MalazAlamir 