### PR TITLE
Make the message validation option accept a block

### DIFF
--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -408,6 +408,7 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
       length: Measured::Length.new(1, :m),
       length_true: Measured::Length.new(2, :cm),
       length_message: Measured::Length.new(3, :mm),
+      length_message_from_block: Measured::Length.new(7, :mm),
       length_units: Measured::Length.new(4, :m),
       length_units_singular: Measured::Length.new(5, :ft),
       length_presence: Measured::Length.new(6, :m),

--- a/test/dummy/app/models/validated_thing.rb
+++ b/test/dummy/app/models/validated_thing.rb
@@ -9,6 +9,9 @@ class ValidatedThing < ActiveRecord::Base
   measured_length :length_message
   validates :length_message, measured: {message: "has a custom failure message"}
 
+  measured_length :length_message_from_block
+  validates :length_message_from_block, measured: { message: Proc.new { |record| "#{record.length_message_from_block_unit} is not a valid unit" } }
+
   measured_length :length_units
   validates :length_units, measured: {units: [:meter, "cm"]}
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 20161118203701) do
     t.string   "length_true_unit",                                limit: 12
     t.decimal  "length_message_value",                                       precision: 10, scale: 2
     t.string   "length_message_unit",                             limit: 12
+    t.decimal  "length_message_from_block_value",                            precision: 10, scale: 2
+    t.string   "length_message_from_block_unit",                  limit: 12
     t.decimal  "length_units_value",                                         precision: 10, scale: 2
     t.string   "length_units_unit",                               limit: 12
     t.decimal  "length_units_singular_value",                                precision: 10, scale: 2

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -38,10 +38,16 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     assert_equal ["Length is not a valid unit"], thing.errors.full_messages
   end
 
-  test "validation can override the message" do
+  test "validation can override the message with a static string" do
     thing.length_message_unit = "junk"
     refute thing.valid?
     assert_equal ["Length message has a custom failure message"], thing.errors.full_messages
+  end
+
+  test "validation can override the message with a block" do
+    thing.length_message_from_block_unit = "junk"
+    refute thing.valid?
+    assert_equal ["Length message from block junk is not a valid unit"], thing.errors.full_messages
   end
 
   test "validation may be any valid unit" do
@@ -198,6 +204,7 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
       length: Measured::Length.new(1, :m),
       length_true: Measured::Length.new(2, :cm),
       length_message: Measured::Length.new(3, :mm),
+      length_message_from_block: Measured::Length.new(7, :mm),
       length_units: Measured::Length.new(4, :m),
       length_units_singular: Measured::Length.new(5, :ft),
       length_presence: Measured::Length.new(6, :m),


### PR DESCRIPTION
### Summary

This PR lets one pass a lambda or proc to the `message` option when adding a new validation. This gives more control in cases where one might need the invalid data to be part of the error message.

### Example
```ruby
class ValidatedThing < ActiveRecord::Base
  measured_length :weight
  validates :weight,
    measured: {
      greater_than_or_equal_to: Measured::Weight.new(0, :g),
      message: Proc.new { |record| "#{record.length_message_from_block_unit} is not a valid unit" }
    }
end
```

cc @mdking @MalazAlamir