### PR TITLE
Fix duplicate error message for non-supported units

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -22,7 +22,7 @@ class MeasuredValidator < ActiveModel::EachValidator
     measurable_unit = measured_class.unit_system.unit_for(measurable_unit_name)
     record.errors.add(attribute, message("is not a valid unit")) unless measurable_unit
 
-    if options[:units]
+    if options[:units] && measurable_unit.present?
       valid_units = Array(options[:units]).map { |unit| measured_class.unit_system.unit_for(unit) }
       record.errors.add(attribute, message("is not a valid unit")) unless valid_units.include?(measurable_unit)
     end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -95,6 +95,13 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     assert_equal ["Length units singular custom message too"], thing.errors.full_messages
   end
 
+  test "validation for unit reasons adds one message if unit is not supported by default and is not custom supported" do
+    thing.length_units_singular_unit = :t
+    refute thing.valid?
+
+    assert_equal ["Length units singular custom message too"], thing.errors.full_messages
+  end
+
   test "validation presence works on measured columns" do
     thing.length_presence = nil
     refute thing.valid?


### PR DESCRIPTION
### Summary
This fixes a silly duplicate error message where if you try to assign a unit that is not supported by the gem at all, the validation message will show twice. 

### Example

Before:

```
[1] pry(#<Measured::Rails::ValidationTest>)> thing.length_units_singular_unit = :t
=> :t
[2] pry(#<Measured::Rails::ValidationTest>)> thing.valid?
=> false
[3] pry(#<Measured::Rails::ValidationTest>)> thing.errors.full_messages
=> ["Length units singular custom message too", "Length units singular custom message too"]
```

After:

```
[1] pry(#<Measured::Rails::ValidationTest>)> thing.length_units_singular_unit = :t
=> :t
[2] pry(#<Measured::Rails::ValidationTest>)> thing.valid?
=> false
[3] pry(#<Measured::Rails::ValidationTest>)> thing.errors.full_messages
=> ["Length units singular custom message too"]
```