### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
### Summary

Release version 2.1.0.

### Changelog
- [measured](https://github.com/Shopify/measured/compare/v2.0.0...v2.1.0).
- [measured-rails](https://github.com/Shopify/measured-rails/compare/ac7a049745c3cf170f84faa2fb174a7d6c7134cf...release_version_2_1_0).

### Observations

measured's version on [gemspec](https://github.com/Shopify/measured-rails/blob/0c53f63368de3dff56748def5b14e3b131d758f1/measured-rails.gemspec#L21-L21) is pointing to `Measured::Rails::VERSION`, so updating it here will do the trick.

cc @mdking @MalazAlamir 