### PR TITLE
Update version to 2.3.0 to match measured

### DIFF
--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,5 +1,5 @@
 module Measured
   module Rails
-    VERSION = "2.2.0"
+    VERSION = "2.3.0"
   end
 end


### PR DESCRIPTION
Bump `measured-rails` to `'2.3.0'` to match [`measured` latest version](https://github.com/Shopify/measured/pull/100).

The only change in this package has been some key removal from our `dev.yml`: https://github.com/Shopify/measured-rails/compare/v2.2.0...be4ae0b