### PR TITLE
Work around bug in rails test formatter and Minitest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,13 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 
 ActiveSupport.test_order = :random
 
+# Prevent two reporters from printing
+# https://github.com/kern/minitest-reporters/issues/230
+# https://github.com/rails/rails/issues/30491
+Minitest.load_plugins
+Minitest.extensions.delete('rails')
+Minitest.extensions.unshift('rails')
+
 Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new(color: true)]
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Our test output is a mess in this gem. Large part is that there are two reporters formatting the output and writing double.

Details in here, but mostly we can just work around it by forcing the rails minitest extension to unload: https://github.com/kern/minitest-reporters/issues/230 https://github.com/rails/rails/issues/30491

```
/home/kevin/.rbenv/versions/2.3.1/bin/ruby -w -I"lib:test:lib/**/*" -I"/home/kevin/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.3.0/lib" "/home/kevin/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.3.0/lib/rake/rake_test_loader.rb" "test/active_record_test.rb" "test/validation_test.rb" 
-- create_table("thing_with_custom_unit_accessors", {:force=>:cascade})
   -> 0.0031s
-- create_table("things", {:force=>:cascade})
   -> 0.0006s
-- create_table("validated_things", {:force=>:cascade})
   -> 0.0007s
Started with run options --seed 9746

Run options: --seed 9746---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=] 0% Time: 00:00:00,  ETA: ??:??:??

# Running:

........  80/9: [==============                                                                                                                    ] 11% Time: 00:00:00,  ETA: ....  80/13: [====================                                                                                                             ] 16% Time: 00:00:00,  ETA: 00:0..../home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_length not initialized
.../home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_total_weight not initialized
./home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized      ] 25% Time: 00:00:00,  ETA: 00:00:00
./home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_total_weight not initialized
..  80/24: [======================================                                                                                           ] 30% Time: 00:00:00,  ETA: 00:00:..../home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
..  80/30: [===============================================                                                                                  ] 37% Time: 00:00:00,  ETA: 00:00:..  80/32: [===================================================                                                                              ] 40% Time: 00:00:00,  ETA: 00:00:./home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: method redefined; discarding old size_unit=
/home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: previous definition of size_unit= was here
/home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: method redefined; discarding old size_unit=
/home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: previous definition of size_unit= was here
/home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: method redefined; discarding old weight_unit=
/home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:78: warning: previous definition of weight_unit= was here
./home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
..../home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized   ] 42% Time: 00:00:00,  ETA: 00:00:00
.  80/39: [=============================================================                                                                    ] 48% Time: 00:00:00,  ETA: 00:00:0......  80/45: [========================================================================                                                         ] 56% Time: 00:00:00,  ETA: 00../home/kevin/source/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
.....  80/52: [===================================================================================                                              ] 65% Time: 00:00:00,  ETA: 00:.....  80/57: [===========================================================================================                                      ] 71% Time: 00:00:00,  ETA: 00:......  80/63: [====================================================================================================                             ] 78% Time: 00:00:00,  ETA: 00.....  80/68: [=============================================================================================================                    ] 85% Time: 00:00:00,  ETA: 00:...  80/71: [=================================================================================================================                ] 88% Time: 00:00:00,  ETA: 00:00......  80/77: [===========================================================================================================================      ] 96% Time: 00:00:00,  ETA: 00...  80/80: [================================================================================================================================] 100% Time: 00:00:00, Time: 00:00:00
.
Finished in 0.25907s
80 tests, 200 assertions, 0 failures, 0 errors, 0 skips


Finished in 0.258836s, 309.0755 runs/s, 772.6887 assertions/s.
80 runs, 200 assertions, 0 failures, 0 errors, 0 skips
```