### PR TITLE
Do not read an instance variable if it is not defined.

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -34,7 +34,7 @@ module Measured::Rails::ActiveRecord
 
           return nil unless value && unit
 
-          instance = instance_variable_get("@measured_#{ field }")
+          instance = instance_variable_get("@measured_#{ field }") if instance_variable_defined?("@measured_#{ field }")
           new_instance = begin
             measured_class.new(value, unit)
           rescue Measured::UnitError


### PR DESCRIPTION
In some cases, where we are overriding the names of the properties used, we will read an ivar that does not yet exist.

It will return `nil` but ruby will spit out a warning.

Here we guard against that and just have it return `nil` without reading if it is not defined. Removes these warnings:

```
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_length not initialized
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_total_weight not initialized
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
/measured-rails/lib/measured/rails/active_record.rb:37: warning: instance variable @measured_width not initialized
```