### PR TITLE
Raise ruby requirement to 2.3 and rails to 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,22 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.1
-  - 2.4.0
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 gemfile:
   - Gemfile
-  - gemfiles/rails-4.2.gemfile
   - gemfiles/rails-5.0.gemfile
+  - gemfiles/rails-5.1.gemfile
   - gemfiles/rails-master.gemfile
 before_script:
   - gem update --system
 matrix:
   exclude:
-    - gemfile: Gemfile
-      rvm: 2.1.8
     - gemfile: gemfiles/rails-master.gemfile
-      rvm: 2.1.8
-    - gemfile: gemfiles/rails-5.0.gemfile
-      rvm: 2.1.8
-    - gemfile: gemfiles/rails-4.2.gemfile
-      rvm: 2.4.0
+      rvm: 2.3.8
+    - gemfile: gemfiles/rails-master.gemfile
+      rvm: 2.4.5
   allow_failures:
     - gemfile: gemfiles/rails-master.gemfile

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 4.2'
-gem 'rack', '< 2.0'
+gem 'rails', '~> 5.1'


### PR DESCRIPTION
This modernizes the requirements for ruby and rails for this gem. ruby >= 2.3 and rails >= 5.0.

Also adds ruby 2.6.

It matches the maintenance policies of both:
https://guides.rubyonrails.org/maintenance_policy.html
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/

Will follow up with a version change.

Matched with https://github.com/Shopify/measured/pull/120