### PR TITLE
Fix warnings by using `method_defined?` or `redefine_method`

### DIFF
--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -72,11 +72,9 @@ module Measured::Rails::ActiveRecord
         end
 
         # Writer to override unit assignment
-        if !method_defined?("#{ unit_field_name }=")
-          define_method("#{ unit_field_name }=") do |incoming|
-            unit_name = measured_class.unit_system.unit_for(incoming).try!(:name)
-            write_attribute(unit_field_name, unit_name || incoming)
-          end
+        redefine_method("#{ unit_field_name }=") do |incoming|
+          unit_name = measured_class.unit_system.unit_for(incoming).try!(:name)
+          write_attribute(unit_field_name, unit_name || incoming)
         end
       end
     end

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -5,7 +5,6 @@ module Measured::Rails::ActiveRecord
     def measured(measured_class, *fields)
       options = fields.extract_options!
       options = {}.merge(options)
-      defined_unit_accessors = []
 
       measured_class = measured_class.constantize if measured_class.is_a?(String)
       unless measured_class.is_a?(Class) && measured_class.ancestors.include?(Measured::Measurable)
@@ -72,13 +71,12 @@ module Measured::Rails::ActiveRecord
           end
         end
 
-        next if defined_unit_accessors.include?(unit_field_name)
-
         # Writer to override unit assignment
-        define_method("#{ unit_field_name }=") do |incoming|
-          defined_unit_accessors << unit_field_name
-          unit_name = measured_class.unit_system.unit_for(incoming).try!(:name)
-          write_attribute(unit_field_name, unit_name || incoming)
+        if !method_defined?("#{ unit_field_name }=")
+          define_method("#{ unit_field_name }=") do |incoming|
+            unit_name = measured_class.unit_system.unit_for(incoming).try!(:name)
+            write_attribute(unit_field_name, unit_name || incoming)
+          end
         end
       end
     end


### PR DESCRIPTION
## Problem

In trying to remove warnings I hit these:

```
measured/rails/active_record.rb:78: warning: method redefined; discarding old size_unit=
measured/rails/active_record.rb:78: warning: previous definition of size_unit= was here
measured/rails/active_record.rb:78: warning: method redefined; discarding old size_unit=
measured/rails/active_record.rb:78: warning: previous definition of size_unit= was here
measured/rails/active_record.rb:78: warning: method redefined; discarding old weight_unit=
measured/rails/active_record.rb:78: warning: previous definition of weight_unit= was here
```

Which is `define_method("#{ unit_field_name }=")` triggering multiple times on redefinition of a field.

This was added in #27


## Solution

There are a few things. First, the `defined_unit_accessors` never actually worked as described because the variable was updated at the wrong level. It is originally defined as `[]` at a class macro scope, but the `<<` was only happening inside the instance definition. So it was never saved.

Moving it down to the right level reduced the warnings, but some still existed as for when a method is redefined in two different calls to the class macro.

So I've settled on using `method_defined?` I think. That checks if it already exists and if it does then do not define it. *This approach may be wrong!* As if the method already exists it won't overwrite it, which may not have been defined by measured.

A different approach as suggested by @gmcgibbon is to use `redefine_method`, meaning that it would then keep the _last_ definition of the method, not the _first_ definition of the method (regardless of where that definition is from). https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/redefine_method.rb