### PR TITLE
Add # frozen_string_literal: true

### DIFF
--- a/lib/measured-rails.rb
+++ b/lib/measured-rails.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "measured/rails/base"
 
 require "measured/rails/units/length"

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Rails::ActiveRecord
   extend ActiveSupport::Concern
 

--- a/lib/measured/rails/base.rb
+++ b/lib/measured/rails/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "measured/rails/version"
 require "measured"
 

--- a/lib/measured/rails/railtie.rb
+++ b/lib/measured/rails/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Rails
   class Railtie < ::Rails::Railtie
   end

--- a/lib/measured/rails/units/length.rb
+++ b/lib/measured/rails/units/length.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Rails::ActiveRecord::Length
   extend ActiveSupport::Concern
 

--- a/lib/measured/rails/units/volume.rb
+++ b/lib/measured/rails/units/volume.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Rails::ActiveRecord::Volume
   extend ActiveSupport::Concern
 

--- a/lib/measured/rails/units/weight.rb
+++ b/lib/measured/rails/units/weight.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Rails::ActiveRecord::Weight
   extend ActiveSupport::Concern
 

--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MeasuredValidator < ActiveModel::EachValidator
   CHECKS = {
     greater_than: :>,

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured
   module Rails
     VERSION = "2.5.0"

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase

--- a/test/support/models/thing.rb
+++ b/test/support/models/thing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Thing < ActiveRecord::Base
 
   measured_length :length, :width
@@ -10,5 +11,4 @@ class Thing < ActiveRecord::Base
   measured "Measured::Weight", :extra_weight
 
   measured_length :length_with_max_on_assignment, {max_on_assignment: 500}
-
 end

--- a/test/support/models/thing_with_custom_unit_accessor.rb
+++ b/test/support/models/thing_with_custom_unit_accessor.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 class ThingWithCustomUnitAccessor < ActiveRecord::Base
-
   measured_length :length, :width, unit_field_name: :size_unit
   validates :length, measured: true
   validates :width, measured: true

--- a/test/support/models/validated_thing.rb
+++ b/test/support/models/validated_thing.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 class ValidatedThing < ActiveRecord::Base
-
   measured_length :length
   validates :length, measured: true
 
@@ -42,5 +42,4 @@ class ValidatedThing < ActiveRecord::Base
   def high_bound
     Measured::Length.new(20, :in)
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "pry" unless ENV["CI"]
 require "measured"
 require "measured-rails"

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::Rails::ValidationTest < ActiveSupport::TestCase


### PR DESCRIPTION
Adds the `# frozen_string_literal: true` comment everywhere.

Related to https://github.com/Shopify/measured/pull/123