### PR TITLE
Fix ruby versions and gem install for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,21 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 gemfile:
   - Gemfile
   - gemfiles/rails-5.0.gemfile
   - gemfiles/rails-5.1.gemfile
   - gemfiles/rails-6.0.gemfile
   - gemfiles/rails-master.gemfile
-before_script:
-  - gem update --system
 matrix:
   exclude:
     - gemfile: gemfiles/rails-master.gemfile
-      rvm: 2.3.8
-    - gemfile: gemfiles/rails-master.gemfile
-      rvm: 2.4.5
+      rvm: 2.4.9
     - gemfile: gemfiles/rails-6.0.gemfile
-      rvm: 2.3.8
-    - gemfile: gemfiles/rails-6.0.gemfile
-      rvm: 2.4.5
+      rvm: 2.4.9
   allow_failures:
     - gemfile: gemfiles/rails-master.gemfile


### PR DESCRIPTION
Mirrors https://github.com/Shopify/measured/pull/130

Supports just the mainline current ruby versions. https://www.ruby-lang.org/en/downloads/