### PR TITLE
Update minitest loader for mocha to remove deprecation

### DIFF
--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "minitest", "> 5.5.1"
   spec.add_development_dependency "minitest-reporters"
-  spec.add_development_dependency "mocha", "> 1.1.0"
+  spec.add_development_dependency "mocha", ">= 1.4.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "sqlite3"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "measured"
 require "measured-rails"
 require "minitest/autorun"
 require "minitest/reporters"
-require "mocha/setup"
+require "mocha/minitest"
 
 ActiveSupport.test_order = :random
 


### PR DESCRIPTION
Mirrors https://github.com/Shopify/measured/pull/131

Fixes a small deprecation in Mocha:

```
Mocha deprecation warning at /Users/kevin/source/measured/test/test_helper.rb:6:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
```

Set minimum version of Mocha where this file is supported to `1.4.0`:
https://github.com/freerange/mocha/blob/master/RELEASE.md#140