### PR TITLE
Rb 49 custom value field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ class ThingWithCustomUnitAccessor < ActiveRecord::Base
 end
 ```
 
+Similarly, you can optionally customize the model's value column by specifying it in the `value_field_name` option, as follows:
+
+```ruby
+class ThingWithCustomValueAccessor < ActiveRecord::Base
+  measured_length :length, value_field_name: :custom_length
+  measured_weight :total_weight, value_field_name: :custom_weight
+  measured_volume :volume, value_field_name: :custom_volume
+end
+```
+
 There are some simpler methods for predefined types:
 
 ```ruby

--- a/lib/measured/rails/active_record.rb
+++ b/lib/measured/rails/active_record.rb
@@ -25,7 +25,11 @@ module Measured::Rails::ActiveRecord
           "#{ field }_unit"
         end
 
-        value_field_name = "#{ field }_value"
+        value_field_name = if options[:value_field_name]
+          measured_fields[field][:value_field_name] = options[:value_field_name].to_s
+        else
+          "#{ field }_value"
+        end
 
         # Reader to retrieve measured object
         define_method(field) do

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -364,6 +364,15 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal custom_unit_thing.extra_weight, Measured::Weight.new(12, :kg)
   end
 
+  test "using custom value fields works correctly" do
+    custom_value_thing.length = Measured::Length.new(4, :m)
+    custom_value_thing.width = Measured::Length.new(5, :m)
+    custom_value_thing.height = Measured::Length.new(6, :m)
+    custom_value_thing.volume = Measured::Volume.new(13, :l)
+    custom_value_thing.total_weight = Measured::Weight.new(14, :g)
+    custom_value_thing.extra_weight = Measured::Weight.new(15, :g)
+  end
+
   private
 
   def length
@@ -408,6 +417,17 @@ class Measured::Rails::ActiveRecordTest < ActiveSupport::TestCase
       volume: Measured::Volume.new(9, :l),
       total_weight: Measured::Weight.new(10, :g),
       extra_weight: Measured::Weight.new(12, :g),
+    )
+  end
+
+  def custom_value_thing
+    @custom_value_thing ||= ThingWithCustomValueAccessor.new(
+      length: Measured::Length.new(4, :m),
+      width: Measured::Length.new(5, :m),
+      height: Measured::Length.new(6, :m),
+      volume: Measured::Volume.new(13, :l),
+      total_weight: Measured::Weight.new(14, :g),
+      extra_weight: Measured::Weight.new(15, :g),
     )
   end
 end

--- a/test/support/models/thing_with_custom_value_accessor.rb
+++ b/test/support/models/thing_with_custom_value_accessor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class ThingWithCustomValueAccessor < ActiveRecord::Base
+  measured_length :length, value_field_name: :custom_length
+  validates :length, measured: true
+  measured_length :width, value_field_name: :custom_length
+  validates :width, measured: true
+
+  measured_volume :volume, value_field_name: :custom_volume
+  validates :volume, measured: true
+
+  measured_length :height, value_field_name: :custom_height
+  validates :height, measured: true
+
+  measured_weight :total_weight, value_field_name: :custom_weight
+  validates :total_weight, measured: true
+
+  measured_weight :extra_weight, value_field_name: :custom_extra_weight
+  validates :extra_weight, measured: true
+end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118203701) do
+ActiveRecord::Schema.define(version: 20211105120355) do
 
   create_table "thing_with_custom_unit_accessors", force: :cascade do |t|
     t.decimal  "length_value",                  precision: 10, scale: 2
@@ -78,6 +78,23 @@ ActiveRecord::Schema.define(version: 20161118203701) do
     t.string   "length_zero_scalar_unit",                         limit: 12
     t.decimal  "length_numericality_less_than_than_scalar_value",            precision: 10, scale: 2
     t.string   "length_numericality_less_than_than_scalar_unit",  limit: 12
+  end
+
+  create_table "thing_with_custom_value_accessors", force: :cascade do |t|
+    t.decimal  "custom_length",                  precision: 10, scale: 2
+    t.string   "length_unit",         limit: 12
+    t.decimal  "custom_width",                   precision: 10, scale: 2
+    t.string   "width_unit",          limit: 12
+    t.decimal  "custom_height",                  precision: 10, scale: 2
+    t.string   "height_unit",         limit: 12
+    t.decimal  "custom_volume",                  precision: 10, scale: 2
+    t.string   "volume_unit",         limit: 12
+    t.decimal  "custom_weight",                  precision: 10, scale: 2, default: "10.0"
+    t.string   "total_weight_unit",   limit: 12
+    t.decimal  "custom_extra_weight",            precision: 10, scale: 2
+    t.string   "extra_weight_unit",   limit: 12
+    t.datetime "created_at",                                                              null: false
+    t.datetime "updated_at",                                                              null: false
   end
 
 end


### PR DESCRIPTION
**WHY**

The gem currently does not support the ability to define a custom database field for values.
This adds support for that.

eg:

```ruby
class ThingWithCustomValueAccessor < ActiveRecord::Base
  measured_length :length, value_field_name: :custom_length
  measured_weight :total_weight, value_field_name: :custom_weight
  measured_volume :volume, value_field_name: :custom_volume
end
```