### PR TITLE
Release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.8.0
+-----
+
+* Support setting a custom value field. (Thanks @Steffylicious)
+* Drop support for Ruby 2.5
+* Use Ruby 3.0.2 for development
+
 2.7.1
 -----
 

--- a/lib/measured/rails/version.rb
+++ b/lib/measured/rails/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Measured
   module Rails
-    VERSION = "2.7.1"
+    VERSION = "2.8.0"
   end
 end


### PR DESCRIPTION
A release to include https://github.com/Shopify/measured-rails/pull/67

It bumps dev ruby and drops support for ruby 2.5. I also renamed `master` to `main`.

Full diff: https://github.com/Shopify/measured-rails/compare/31bd920c55e915dd111726fb1461892a1308cfe9...9abdb5487348611beadd563c075171e215b1286f

https://github.com/Shopify/measured/pull/139 was already shipped to `2.8.0` as well.