### PR TITLE
Allow custom value accessors with validations

### DIFF
--- a/lib/measured/rails/validations.rb
+++ b/lib/measured/rails/validations.rb
@@ -11,7 +11,7 @@ class MeasuredValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, measurable)
     measured_config = record.class.measured_fields[attribute]
     unit_field_name = measured_config[:unit_field_name] || "#{ attribute }_unit"
-    value_field_name = "#{ attribute }_value"
+    value_field_name = measured_config[:value_field_name] || "#{ attribute }_value"
 
     measured_class = measured_config[:class]
 

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -205,6 +205,10 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
     assert_equal(custom_unit_thing.errors[:width], ["is not a valid unit"])
   end
 
+  test "validations work as expected on measured field with custom value accessor" do
+    assert custom_value_thing.valid?
+  end
+
   private
 
   def thing
@@ -224,6 +228,16 @@ class Measured::Rails::ValidationTest < ActiveSupport::TestCase
 
   def custom_unit_thing
     @custom_unit_thing ||= ThingWithCustomUnitAccessor.new(
+      length: Measured::Length.new(1, :m),
+      width: Measured::Length.new(2, :m),
+      height: Measured::Length.new(3, :m),
+      total_weight: Measured::Weight.new(10, :g),
+      extra_weight: Measured::Weight.new(12, :g),
+    )
+  end
+
+  def custom_value_thing
+    @custom_value_thing = ThingWithCustomValueAccessor.new(
       length: Measured::Length.new(1, :m),
       width: Measured::Length.new(2, :m),
       height: Measured::Length.new(3, :m),


### PR DESCRIPTION
This just copies the functionality already available for custom
unit accessors. Seems like just an oversight that it wasn't
included for value accessors