### PR TITLE
Add Tapioca::Dsl::Compilers::MeasuredRails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 -----
 
+* Add Tapioca DSL compiler
 * Drop support for Ruby 2.6
 
 2.8.2

--- a/lib/tapioca/dsl/compilers/measured_rails.rb
+++ b/lib/tapioca/dsl/compilers/measured_rails.rb
@@ -1,0 +1,112 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "tapioca/dsl"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::MeasuredRails` refines RBI files for subclasses of
+      # [`ActiveRecord::Base`](https://api.rubyonrails.org/classes/ActiveRecord/Base.html)
+      # that utilize the [`measured-rails`](https://github.com/shopify/measured-rails) DSL.
+      # This compiler is only responsible for defining the methods that would be created
+      # for measured fields that are defined in the Active Record model.
+      #
+      # For example, with the following model class:
+      #
+      # ~~~rb
+      # class Package < ActiveRecord::Base
+      #   measured Measured::Weight, :minimum_weight
+      #   measured Measured::Length, :total_length
+      #   measured Measured::Volume, :total_volume
+      # end
+      # ~~~
+      #
+      # this compiler will produce the following methods in the RBI file
+      # `package.rbi`:
+      #
+      # ~~~rbi
+      # # package.rbi
+      # # typed: true
+      #
+      # class Package
+      #   include GeneratedMeasuredRailsMethods
+      #
+      #   module GeneratedMeasuredRailsMethods
+      #     sig { returns(T.nilable(Measured::Weight)) }
+      #     def minimum_weight; end
+      #
+      #     sig { params(value: T.nilable(Measured::Weight)).void }
+      #     def minimum_weight=(value); end
+      #
+      #     sig { returns(T.nilable(Measured::Length)) }
+      #     def total_length; end
+      #
+      #     sig { params(value: T.nilable(Measured::Length)).void }
+      #     def total_length=(value); end
+      #
+      #     sig { returns(T.nilable(Measured::Volume)) }
+      #     def total_volume; end
+      #
+      #     sig { params(value: T.nilable(Measured::Volume)).void }
+      #     def total_volume=(value); end
+      #   end
+      # end
+      # ~~~
+      class MeasuredRails < ::Tapioca::Dsl::Compiler
+        extend T::Sig
+
+        ConstantType = type_member { {
+          fixed: T.all(
+            T.class_of(::ActiveRecord::Base),
+            ::Measured::Rails::ActiveRecord::ClassMethods
+          )
+        } }
+
+        MeasuredMethodsModuleName = T.let("GeneratedMeasuredRailsMethods", String)
+
+        sig { override.void }
+        def decorate
+          return if constant.measured_fields.empty?
+
+          root.create_path(constant) do |model|
+            model.create_module(MeasuredMethodsModuleName) do |mod|
+              populate_measured_methods(mod)
+            end
+
+            model.create_include(MeasuredMethodsModuleName)
+          end
+        end
+
+        sig { override.returns(T::Enumerable[Module]) }
+        def self.gather_constants
+          descendants_of(::ActiveRecord::Base)
+        end
+
+        private
+
+        sig { params(model: RBI::Scope).void }
+        def populate_measured_methods(model)
+          constant.measured_fields.each do |field, attrs|
+            klass = attrs[:class].to_s
+
+            model.create_method(
+              field.to_s,
+              return_type: as_nilable_type(klass)
+            )
+
+            model.create_method(
+              "#{field}=",
+              parameters: [create_param("value", type: as_nilable_type(klass))],
+              return_type: "void"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", ">= 1.4.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "tapioca"
 
   spec.required_ruby_version = ">= 2.7"
 end

--- a/test/tapioca/dsl/compilers/measured_rails_test.rb
+++ b/test/tapioca/dsl/compilers/measured_rails_test.rb
@@ -1,0 +1,220 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require "sorbet-runtime"
+require "tapioca/helpers/test/dsl_compiler"
+require "tapioca/dsl/compilers/measured_rails"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class MeasuredRailsTest < ActiveSupport::TestCase
+        include Tapioca::Helpers::Test::DslCompiler
+
+        setup do
+          use_dsl_compiler(Tapioca::Dsl::Compilers::MeasuredRails)
+        end
+
+        test "#initilize gathers only ActiveRecord subclasses" do
+          add_ruby_file("content.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+            end
+            class Current
+            end
+          RUBY
+
+          assert_includes(gathered_constants, "Post")
+          refute_includes(gathered_constants, "Current")
+        end
+
+        test "generates empty RBI file if there are no measured fields" do
+          add_ruby_file("package.rb", <<~RUBY)
+            class Package < ActiveRecord::Base
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+          RBI
+
+          assert_equal(expected, rbi_for(:Package))
+        end
+
+        test "generates RBI file for measured method" do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :packages do |t|
+                  t.decimal :minimum_weight_value, precision: 10, scale: 2
+                  t.string :minimum_weight_unit, limit: 12
+                  t.decimal :total_length_value, precision: 10, scale: 2, default: 0
+                  t.string :total_length_unit, limit: 12, default: "cm"
+                  t.decimal :total_volume_value, precision: 10, scale: 2, default: 0
+                  t.string :total_volume_unit, limit: 12, default: "l"
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("package.rb", <<~RUBY)
+            class Package < ActiveRecord::Base
+              measured Measured::Weight, :minimum_weight
+              measured Measured::Length, :total_length
+              measured Measured::Volume, :total_volume
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Package
+              include GeneratedMeasuredRailsMethods
+
+              module GeneratedMeasuredRailsMethods
+                sig { returns(T.nilable(Measured::Weight)) }
+                def minimum_weight; end
+
+                sig { params(value: T.nilable(Measured::Weight)).void }
+                def minimum_weight=(value); end
+
+                sig { returns(T.nilable(Measured::Length)) }
+                def total_length; end
+
+                sig { params(value: T.nilable(Measured::Length)).void }
+                def total_length=(value); end
+
+                sig { returns(T.nilable(Measured::Volume)) }
+                def total_volume; end
+
+                sig { params(value: T.nilable(Measured::Volume)).void }
+                def total_volume=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Package))
+        end
+
+        test "generates RBI file for measured_weight method" do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :packages do |t|
+                  t.decimal :minimum_weight_value, precision: 10, scale: 2
+                  t.string :minimum_weight_unit, limit: 12
+                  t.decimal :total_length_value, precision: 10, scale: 2, default: 0
+                  t.string :total_length_unit, limit: 12, default: "cm"
+                  t.decimal :total_volume_value, precision: 10, scale: 2, default: 0
+                  t.string :total_volume_unit, limit: 12, default: "l"
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("package.rb", <<~RUBY)
+            class Package < ActiveRecord::Base
+              measured_weight :minimum_weight
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Package
+              include GeneratedMeasuredRailsMethods
+
+              module GeneratedMeasuredRailsMethods
+                sig { returns(T.nilable(Measured::Weight)) }
+                def minimum_weight; end
+
+                sig { params(value: T.nilable(Measured::Weight)).void }
+                def minimum_weight=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Package))
+        end
+
+        test "generates RBI file for measured_length method" do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :packages do |t|
+                  t.decimal :minimum_weight_value, precision: 10, scale: 2
+                  t.string :minimum_weight_unit, limit: 12
+                  t.decimal :total_length_value, precision: 10, scale: 2, default: 0
+                  t.string :total_length_unit, limit: 12, default: "cm"
+                  t.decimal :total_volume_value, precision: 10, scale: 2, default: 0
+                  t.string :total_volume_unit, limit: 12, default: "l"
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("package.rb", <<~RUBY)
+            class Package < ActiveRecord::Base
+              measured_length :total_length
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Package
+              include GeneratedMeasuredRailsMethods
+
+              module GeneratedMeasuredRailsMethods
+                sig { returns(T.nilable(Measured::Length)) }
+                def total_length; end
+
+                sig { params(value: T.nilable(Measured::Length)).void }
+                def total_length=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Package))
+        end
+
+        test "generates RBI file for measured_volume method" do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :packages do |t|
+                  t.decimal :total_volume_value, precision: 10, scale: 2, default: 0
+                  t.string :total_volume_unit, limit: 12, default: "l"
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("package.rb", <<~RUBY)
+            class Package < ActiveRecord::Base
+              measured_volume :total_volume
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Package
+              include GeneratedMeasuredRailsMethods
+
+              module GeneratedMeasuredRailsMethods
+                sig { returns(T.nilable(Measured::Volume)) }
+                def total_volume; end
+
+                sig { params(value: T.nilable(Measured::Volume)).void }
+                def total_volume=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Package))
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,9 @@ require "minitest/autorun"
 require "minitest/reporters"
 require "mocha/minitest"
 
+# Disable Ruby VERBOSE mode to prevent sorbet-runtime from printing redefined warnings.
+$VERBOSE = false
+
 ActiveSupport.test_order = :random
 
 # Prevent two reporters from printing


### PR DESCRIPTION
It is difficult to add typing information to sytems when models utilize `measured_rails` currently because there's no typing for the generated methods. This PR adds a tapioca compiler to do this. Historically, these seem to be put into tapioca itself, but [this snippet](https://github.com/Shopify/tapioca/blob/95d76a41fafa3466e2149a1a6b81015c5a669be5/lib/tapioca/loaders/dsl.rb#L53-L55) frees us up to put these compilers directly into the gems that implement a DSL.

I had originally written this to go into tapioca itself, but had someone recommend that I add it here.

Currently CI is failing for ruby 2.6 which has reached its end of life. Relies on #72 to be mergable.