### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -23,10 +22,6 @@ jobs:
           - gemfiles/rails-7.0.gemfile
           - gemfiles/rails-edge.gemfile
         exclude:
-          - ruby: '2.6'
-            gemfile: gemfiles/rails-edge.gemfile
-          - ruby: '2.6'
-            gemfile: gemfiles/rails-7.0.gemfile
           - ruby: '3.0'
             gemfile: gemfiles/rails-5.2.gemfile
           - ruby: '3.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased
 -----
 
-
+* Drop support for Ruby 2.6
 
 2.8.2
 -----

--- a/measured-rails.gemspec
+++ b/measured-rails.gemspec
@@ -38,4 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", ">= 1.4.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "sqlite3"
+
+  spec.required_ruby_version = ">= 2.7"
 end


### PR DESCRIPTION
Ruby 2.6 has reached its end of life and continuing to support it is preventing CI from working while adding newer features like [Tapioca support](https://github.com/Shopify/measured-rails/pull/71).

This PR removes ruby 2.6 from CI, but also adds a minimum required version so that this doesn't get installed in older versions of Ruby. Our pinned dependencies also require ruby 2.7 so I think this makes sense.