### PR TITLE
Small DSL compiler refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           - gemfiles/rails-6.1.gemfile
           - gemfiles/rails-7.0.gemfile
           - gemfiles/rails-edge.gemfile
+        exclude:
+          # Rails Edge only supports Ruby >= 3.1
+          - ruby: '3.0'
+            gemfile: gemfiles/rails-edge.gemfile
     name: Ruby ${{ matrix.ruby }} ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v1

--- a/lib/tapioca/dsl/compilers/measured_rails.rb
+++ b/lib/tapioca/dsl/compilers/measured_rails.rb
@@ -1,11 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-begin
-  require "tapioca/dsl"
-rescue LoadError
-  return
-end
+return unless defined?(::Measured::Rails::ActiveRecord)
 
 module Tapioca
   module Dsl

--- a/test/tapioca/dsl/compilers/measured_rails_test.rb
+++ b/test/tapioca/dsl/compilers/measured_rails_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "sorbet-runtime"
+require "tapioca/internal"
 require "tapioca/helpers/test/dsl_compiler"
 require "tapioca/dsl/compilers/measured_rails"
 
@@ -16,7 +16,7 @@ module Tapioca
           use_dsl_compiler(Tapioca::Dsl::Compilers::MeasuredRails)
         end
 
-        test "#initilize gathers only ActiveRecord subclasses" do
+        test "#initialize gathers only ActiveRecord subclasses" do
           add_ruby_file("content.rb", <<~RUBY)
             class Post < ActiveRecord::Base
             end


### PR DESCRIPTION
Now that Tapioca has adopted the pattern of not defining the DSL compiler if the target class for the DSL is not defined at all, we should be using it in this gem's DSL compiler as well.

I also had to exclude Rails edge + Ruby 3.0 from the build matrix so that the CI can be green.